### PR TITLE
Implementing server pings

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/IMessageHandler.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/IMessageHandler.cs
@@ -13,5 +13,5 @@ public interface IMessageHandler
 
     Task ProcessMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken);
 
-    Task StartAsync(CancellationToken cancellationToken, Func<string, string> endpointWriter);
+    Task RunAsync(Func<string, string> endpointWriter, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultRequestHandler.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultRequestHandler.cs
@@ -23,7 +23,7 @@ internal sealed class DefaultRequestHandler(IMessageHandlerManager messageHandle
 
         try
         {
-            await handler.StartAsync(context.RequestAborted, (clientId) => WriteEndpoint(clientId, context));
+            await handler.RunAsync(clientId => WriteEndpoint(clientId, context), context.RequestAborted);
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/TokenUtility.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/TokenUtility.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp;
 
-internal class TokenUtility
+internal sealed class TokenUtility
 {
     private const int KeySize = 32;
     private const int IvSize = 12;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyAttribute.cs
@@ -10,6 +10,7 @@ public sealed class McpToolPropertyAttribute(string propertyName, string propert
     : this(string.Empty, string.Empty, string.Empty)
     {
     }
+
     public string PropertyName { get; set; } = propertyName;
 
     public string PropertyType { get; set; } = propertyType;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolTriggerAttribute.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 [ConverterFallbackBehavior(ConverterFallbackBehavior.Default)]
 public sealed class McpToolTriggerAttribute(string toolName, string? description = null) : TriggerBindingAttribute
 {
-
     /// <summary>
     /// Gets or sets the name of the MCP tool.
     /// </summary>


### PR DESCRIPTION
This PR introduces server pings functionality.

This intitial implementation simply pings the client every 25 seconds to keep the connection alive. No action taken by the server if the client does not respond to pings. 