### PR TITLE
Adding support for configurable server information and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 Extension to enable MCP support to Azure Functions.
 
+## Instructions
+
+To get started with the extension, please see the following samples:
+
+| Language (Stack) | Repo Location |
+|------------------|---------------|
+| C# (.NET) | [remote-mcp-functions-dotnet](https://github.com/Azure-Samples/remote-mcp-functions-dotnet) |
+| Python | [remote-mcp-functions-python](https://github.com/Azure-Samples/remote-mcp-functions-python) |
+| TypeScript (Node.js) | [remote-mcp-functions-typescript](https://github.com/Azure-Samples/remote-mcp-functions-typescript) |
+
+### Configuration
+
+You can configure the extension behavior using the `host.json` file. The following is an example of the configurable settings:
+
+``` json
+{
+  "version": "2.0",
+  "extensions": {
+    "mcp": {
+      "instructions": "Some test instructions on how to use the server",
+      "serverName": "TestServer",
+      "serverVersion": "2.0.0"
+    }
+  }
+}
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Configuration/McpOptions.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Configuration/McpOptions.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Azure.Functions.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Options for configuring the Model Context Protocol (MCP) extension in Azure Functions.
+/// </summary>
+public sealed class McpOptions
+{
+    /// <summary>
+    /// Gets or sets the name of the server that is returned to the client in the initialization response.
+    /// </summary>
+    public string ServerName { get; set; } = "Azure Functions MCP server";
+
+    /// <summary>
+    /// Gets or sets the server version that is returned to the client in the initialization response.
+    /// </summary>
+    public string ServerVersion { get; set; } = "1.0.0";
+
+    /// <summary>
+    /// Gets or sets the instructions returned to the client in the initialization response.
+    /// </summary>
+    public string? Instructions { get; set; }
+}

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultMcpInstanceIdProvider.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultMcpInstanceIdProvider.cs
@@ -4,11 +4,6 @@ namespace Microsoft.Extensions.Hosting
 {
     internal class DefaultMcpInstanceIdProvider : IMcpInstanceIdProvider
     {
-        public DefaultMcpInstanceIdProvider()
-        {
-            InstanceId = Guid.NewGuid().ToString();
-        }
-
-        public string InstanceId { get; }
+        public string InstanceId { get; } = Guid.NewGuid().ToString();
     }
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/McpExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/McpExtensionConfigProvider.cs
@@ -22,7 +22,7 @@ internal sealed class McpExtensionConfigProvider(IToolRegistry toolRegistry, IRe
         var uri = context.GetWebhookHandler();
 
         loggerFactory.CreateLogger("Host.Function.Console")
-            .LogInformation("MCP server SSE endpoint: {Uri}/sse", uri.GetLeftPart(UriPartial.Path));
+            .LogInformation("MCP server SSE endpoint: {uri}/sse", uri?.GetLeftPart(UriPartial.Path) ?? string.Empty);
 
         _webhookDelegate = () => webHookProvider.GetUrl(this);
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/McpWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/McpWebJobsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.Functions.Extensions.Mcp;
 using Microsoft.Azure.Functions.Extensions.Mcp.Abstractions;
 using Microsoft.Azure.Functions.Extensions.Mcp.Backplane.Storage;
+using Microsoft.Azure.Functions.Extensions.Mcp.Configuration;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +32,8 @@ public static class McpWebJobsBuilderExtensions
         builder.Services.AddSingleton<QueueServiceClientProvider>();
         builder.Services.AddAzureClientsCore();
 
-        builder.AddExtension<McpExtensionConfigProvider>();
+        builder.AddExtension<McpExtensionConfigProvider>()
+            .BindOptions<McpOptions>();
 
         return builder;
     }


### PR DESCRIPTION
resolves #21 

This change adds support for configurable server information (`serverInfo`) and instructions, using`host.json` configuration settings.

The following properties, all returned in the initialization response, are now configurable:

  - Server name: The name of the server (previously, and still defaults to, "Azure Functions MCP server.")
  - Server version: The version of the server (previously computed, now defaults to, "1.0.0")
  - Instructions: Instructions returned to the

Here's an example `host.json` file configuring those properties:

``` json
{
  "version": "2.0",
  "extensions": {
    "mcp": {
      "instructions": "Some test instructions on how to use the server",
      "serverName": "TestServer",
      "serverVersion": "2.0.0"
    }
  }
}
```

We should also make host.json schema updates once this goes out of preview.