### PR TITLE
Restricting ID generation to a set of valid characters

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Utility.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Utility.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.WebUtilities;
 
 
@@ -6,10 +7,27 @@ namespace Microsoft.Azure.Functions.Extensions.Mcp;
 
 internal class Utility
 {
+    private const string ValidChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+    private const int MaxByte = 252; // 252 is the largest multiple of 36 (the valid chars array) under 256
+    private const int Length = 16;
+
     internal static string CreateId()
     {
-        Span<byte> buffer = stackalloc byte[16];
-        RandomNumberGenerator.Fill(buffer);
-        return WebEncoders.Base64UrlEncode(buffer);
+        Span<char> result = stackalloc char[Length];
+        Span<byte> buffer = stackalloc byte[1];
+        var count = 0;
+
+        while (count < Length)
+        {
+            RandomNumberGenerator.Fill(buffer);
+            var value = buffer[0];
+
+            if (value < MaxByte)
+            {
+                result[count++] = ValidChars[value % ValidChars.Length];
+            }
+        }
+
+        return new string(result);
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Restricting ID generation to a set of valid characters to ensure this ID is safe to use for other resources (e.g., storage queues)

The valid characters will be:  "abcdefghijklmnopqrstuvwxyz0123456789"

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)
