### PR TITLE
Delay adding attribute to ensure Version is finalized

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Worker.Extensions.Mcp.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Worker.Extensions.Mcp.csproj
@@ -11,11 +11,13 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
-      <_Parameter1>Microsoft.Azure.Functions.Extensions.Mcp</_Parameter1>
-      <_Parameter2>$(Version)</_Parameter2>
-    </AssemblyAttribute>
-  </ItemGroup>
+  <Target Name="IncludeExtensionInformationAttribute" BeforeTargets="GenerateAdditionalSources">
+    <ItemGroup>
+      <AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
+        <_Parameter1>Microsoft.Azure.Functions.Worker.Extensions.Mcp</_Parameter1>
+        <_Parameter2>$(Version)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Delays adding `ExtensionInformationAttribute` by moving to a target. This ensures the `$(Version)` is finalized, as post-csproj imports currently update it.
