### PR TITLE
Implement TypeConverter for worker extension

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/TypeConverter.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/TypeConverter.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Converters;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Converters;
+
+internal class TypeConverter : IInputConverter
+{
+    public ValueTask<ConversionResult> ConvertAsync(ConverterContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Only expecting a single argument, otherwise use a different converter
+        if (!context.FunctionContext.TryGetToolInvocationContext(out ToolInvocationContext? toolContext)
+            || toolContext.Arguments?.Count != 1)
+        {
+            return new ValueTask<ConversionResult>(ConversionResult.Unhandled());
+        }
+
+        object? argValue = toolContext.Arguments.Values.FirstOrDefault();
+
+        if (argValue is JsonElement jsonElement)
+        {
+            var conversionResult = GetJsonElementConversion(jsonElement, context.TargetType);
+            return new ValueTask<ConversionResult>(conversionResult);
+        }
+
+        if (argValue is not null && context.TargetType.IsAssignableFrom(argValue.GetType()))
+        {
+            return new ValueTask<ConversionResult>(ConversionResult.Success(argValue));
+        }
+
+        return new ValueTask<ConversionResult>(ConversionResult.Unhandled());
+    }
+
+    private ConversionResult GetJsonElementConversion(JsonElement jsonElement, Type targetType) => jsonElement.ValueKind switch
+    {
+        JsonValueKind.String when targetType == typeof(string) =>
+            ConversionResult.Success(jsonElement.GetString()),
+
+        JsonValueKind.Number when targetType == typeof(int) && jsonElement.TryGetInt32(out var i) =>
+            ConversionResult.Success(i),
+
+        JsonValueKind.Number when targetType == typeof(long) && jsonElement.TryGetInt64(out var l) =>
+            ConversionResult.Success(l),
+
+        JsonValueKind.Number when targetType == typeof(float) && jsonElement.TryGetSingle(out var f) =>
+            ConversionResult.Success(f),
+
+        JsonValueKind.Number when targetType == typeof(double) && jsonElement.TryGetDouble(out var d) =>
+            ConversionResult.Success(d),
+
+        JsonValueKind.Number when targetType == typeof(decimal) && jsonElement.TryGetDecimal(out var m) =>
+            ConversionResult.Success(m),
+
+        JsonValueKind.True when targetType == typeof(bool) =>
+            ConversionResult.Success(true),
+
+        JsonValueKind.False when targetType == typeof(bool) =>
+            ConversionResult.Success(false),
+
+        JsonValueKind.Null when !targetType.IsValueType || Nullable.GetUnderlyingType(targetType) is not null =>
+            ConversionResult.Success(null),
+
+        _ => ConversionResult.Unhandled()
+    };
+}
+

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyAttribute.cs
@@ -3,10 +3,12 @@
 
 using Microsoft.Azure.Functions.Worker.Converters;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Converters;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 
-[ConverterFallbackBehavior(ConverterFallbackBehavior.Default)]
+[InputConverter(typeof(TypeConverter))]
+[ConverterFallbackBehavior(ConverterFallbackBehavior.Disallow)]
 public sealed class McpToolPropertyAttribute(string propertyName, string propertyType, string description, bool required = false) : InputBindingAttribute
 {
     public McpToolPropertyAttribute()
@@ -19,6 +21,6 @@ public sealed class McpToolPropertyAttribute(string propertyName, string propert
     public string PropertyType { get; set; } = propertyType;
 
     public string? Description { get; set; } = description;
-    
+
     public bool Required { get; set; } = required;
 }

--- a/test/TestAppIsolated/ToolFunctions.cs
+++ b/test/TestAppIsolated/ToolFunctions.cs
@@ -15,6 +15,17 @@ public class TestFunction
         _logger = logger;
     }
 
+    [Function(nameof(SayHello))]
+    public string SayHello(
+        [McpToolTrigger(nameof(SayHello), "Responds to the user with a hello message.")] ToolInvocationContext context,
+        [McpToolProperty(nameof(name), "string", "The name of the person to greet.")] string? name
+    )
+    {
+        _logger.LogInformation("C# MCP tool trigger function processed a request.");
+        var entityToGreet = context?.Arguments?.GetValueOrDefault("name") ?? "world";
+        return $"Hello, {entityToGreet}! This is an MCP Tool!";
+    }
+
     [Function(nameof(GetSnippet))]
     public object GetSnippet(
         [McpToolTrigger(GetSnippetToolName, GetSnippetToolDescription)] ToolInvocationContext context,
@@ -35,7 +46,9 @@ public class TestFunction
     }
 
     [Function(nameof(SearchSnippets))]
-    public object SearchSnippets([McpToolTrigger(SearchSnippetsToolName, SearchSnippetsToolDescription)] SnippetSearchRequest searchRequest)
+    public object SearchSnippets(
+        [McpToolTrigger(SearchSnippetsToolName, SearchSnippetsToolDescription)] SnippetSearchRequest searchRequest,
+        ToolInvocationContext context)
     {
         var comparisonType = searchRequest.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
         return SnippetsCache.Snippets

--- a/test/Worker.Extensions.Mcp.Tests/ConverterTests/TypeConverterTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/ConverterTests/TypeConverterTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Converters;
+using Moq;
+using static Worker.Extensions.Mcp.Tests.Helpers.ConverterContextHelper;
+using static Worker.Extensions.Mcp.Tests.Helpers.FunctionContextHelper;
+
+namespace Worker.Extensions.Mcp.Tests.ConverterTests;
+
+public class TypeConverterTests
+{
+    [Theory]
+    [MemberData(nameof(SupportedTypesTestCases))]
+    public async Task ConvertAsync_SupportedTypes_ReturnsSuccess(Type targetType, object inputValue, object expectedValue)
+    {
+        var converter = new TypeConverter();
+        var arguments = new Dictionary<string, object> { { "value", inputValue } };
+        var toolContext = new ToolInvocationContext { Name = "test", Arguments = arguments };
+
+        var functionContext = CreateFunctionContextWithToolContext(toolContext);
+        var context = CreateConverterContext(targetType, null, functionContext);
+
+        var result = await converter.ConvertAsync(context);
+
+        Assert.Equal(ConversionStatus.Succeeded, result.Status);
+        Assert.Equal(expectedValue, result.Value);
+    }
+
+    public static IEnumerable<object[]> SupportedTypesTestCases()
+    {
+        yield return new object[] { typeof(string), "hello", "hello" };
+        yield return new object[] { typeof(string), JsonSerializer.SerializeToElement("hello"), "hello" };
+
+        yield return new object[] { typeof(int), 42, 42 };
+        yield return new object[] { typeof(int), JsonSerializer.SerializeToElement(42), 42 };
+
+        yield return new object[] { typeof(long), 123L, 123L };
+        yield return new object[] { typeof(long), JsonSerializer.SerializeToElement(123L), 123L };
+
+        yield return new object[] { typeof(float), 1.23f, 1.23f };
+        yield return new object[] { typeof(float), JsonSerializer.SerializeToElement(1.23f), 1.23f };
+
+        yield return new object[] { typeof(double), 3.14, 3.14 };
+        yield return new object[] { typeof(double), JsonSerializer.SerializeToElement(3.14), 3.14 };
+
+        yield return new object[] { typeof(decimal), 99.99m, 99.99m };
+        yield return new object[] { typeof(decimal), JsonSerializer.SerializeToElement(99.99m), 99.99m };
+
+        yield return new object[] { typeof(bool), true, true };
+        yield return new object[] { typeof(bool), false, false };
+        yield return new object[] { typeof(bool), JsonSerializer.SerializeToElement(true), true };
+        yield return new object[] { typeof(bool), JsonSerializer.SerializeToElement(false), false };
+
+        yield return new object[] { typeof(string), JsonSerializer.SerializeToElement(""), "" };
+
+        yield return new object[] { typeof(int?), JsonDocument.Parse("null").RootElement, null! };
+        yield return new object[] { typeof(string), JsonDocument.Parse("null").RootElement, null! };
+    }
+
+    [Fact]
+    public async Task ConvertAsync_ContextIsNull_ThrowsArgumentNullException()
+    {
+        var converter = new TypeConverter();
+        await Assert.ThrowsAsync<ArgumentNullException>(() => converter.ConvertAsync(null!).AsTask());
+    }
+
+    [Fact]
+    public async Task ConvertAsync_ToolInvocationContextMissing_ReturnsUnhandled()
+    {
+        var converter = new TypeConverter();
+        var functionContext = CreateEmptyFunctionContext();
+        var context = CreateConverterContext(typeof(string), null, functionContext);
+
+        var result = await converter.ConvertAsync(context);
+
+        Assert.Equal(ConversionStatus.Unhandled, result.Status);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_ArgumentsCountIsZero_ReturnsUnhandled()
+    {
+        var converter = new TypeConverter();
+        var toolContext = new ToolInvocationContext { Name = "test", Arguments = new Dictionary<string, object>() };
+        var functionContext = CreateFunctionContextWithToolContext(toolContext);
+        var context = CreateConverterContext(typeof(string), null, functionContext);
+
+        var result = await converter.ConvertAsync(context);
+
+        Assert.Equal(ConversionStatus.Unhandled, result.Status);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_ArgumentsCountMoreThanOne_ReturnsUnhandled()
+    {
+        var converter = new TypeConverter();
+        var toolContext = new ToolInvocationContext
+        {
+            Name = "test",
+            Arguments = new Dictionary<string, object>
+            {
+                { "a", 1 },
+                { "b", 2 }
+            }
+        };
+
+        var functionContext = CreateFunctionContextWithToolContext(toolContext);
+        var context = CreateConverterContext(typeof(int), null, functionContext);
+
+        var result = await converter.ConvertAsync(context);
+
+        Assert.Equal(ConversionStatus.Unhandled, result.Status);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_TypeMismatch_ReturnsUnhandled()
+    {
+        var converter = new TypeConverter();
+        var arguments = new Dictionary<string, object> { { "value", 123 } };
+        var toolContext = new ToolInvocationContext { Name = "test", Arguments = arguments };
+        var functionContext = CreateFunctionContextWithToolContext(toolContext);
+        var context = CreateConverterContext(typeof(string), null, functionContext);
+
+        var result = await converter.ConvertAsync(context);
+
+        Assert.Equal(ConversionStatus.Unhandled, result.Status);
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #70

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- Implemented a TypeConverter that uses the ToolInvocationContext instead of source
  - The expectation is that there is only argument in the Arguments dictionary for this converter to work
  - I also noticed that we get `JsonElement` types from `ToolInvocationContext` so I implemented a switch to handle those cases too.
- Fixes #70 as we are not longer using the built-in TypeConverter that would return an empty string instead of Unhandled.

Questions

1. Do we want to break this convert our into multiple?
2. Do we need to implement other type converters i.e. DateTime etc.?