### PR TITLE
Replace `IOptionsSnapshot` with `IOptionsMonitor`

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataProvider.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 
-public sealed class McpFunctionMetadataProvider(IFunctionMetadataProvider inner, IOptionsSnapshot<ToolOptions> toolOptionsSnapshot)
+public sealed class McpFunctionMetadataProvider(IFunctionMetadataProvider inner, IOptionsMonitor<ToolOptions> toolOptionsSnapshot)
     : IFunctionMetadataProvider
 {
     private const string FunctionsWorkerDirectoryKey = "FUNCTIONS_WORKER_DIRECTORY";

--- a/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataProviderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataProviderTests.cs
@@ -102,7 +102,7 @@ public class McpFunctionMetadataProviderTests
         mockInner.Setup(i => i.GetFunctionMetadataAsync(It.IsAny<string>()))
             .ReturnsAsync([functionMetadata.Object]);
 
-        var mockOptions = new Mock<IOptionsSnapshot<ToolOptions>>();
+        var mockOptions = new Mock<IOptionsMonitor<ToolOptions>>();
         mockOptions.Setup(o => o.Get(It.IsAny<string>()))
             .Returns(new ToolOptions { Properties = toolProperties ?? new List<ToolProperty>() });
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#99](https://github.com/Azure/azure-functions-mcp-extension/issues/99)

This PR replaces `IOptionsSnapshot` with `IOptionsMonitor` to have the DI work when the `DOTNET_ENVIRONMENT` env is set to `Development`.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
