### PR TITLE
Ensuring binding data dictionaries are case-insensitive

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpToolTriggerBinding.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpToolTriggerBinding.cs
@@ -28,7 +28,7 @@ internal sealed class McpToolTriggerBinding : ITriggerBinding
         _toolAttribute = toolAttribute;
         _triggerParameter = triggerParameter;
 
-        BindingDataContract = new Dictionary<string, Type>
+        BindingDataContract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
         {
             { triggerParameter.Name!, triggerParameter.ParameterType },
             { "mcptoolcontext", typeof(ToolInvocationContext) },
@@ -57,7 +57,7 @@ internal sealed class McpToolTriggerBinding : ITriggerBinding
             triggerValue = JsonSerializer.Serialize(invocationContext, McpJsonSerializerOptions.DefaultOptions);
         }
 
-        var bindingData = new Dictionary<string, object>
+        var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
         {
             ["mcptoolcontext"] = invocationContext,
             [_triggerParameter.Name!] = triggerValue,

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -8,6 +8,7 @@
 
 - Enforcing required properties in MCP Extension (#105)
 - Built-in array support (#117)
+- Updated binding data to ensure payload and contracts are case insensitive (#121)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.0.0-preview.8
 

--- a/test/Extensions.Mcp.Tests/McpToolTriggerBindingTests.cs
+++ b/test/Extensions.Mcp.Tests/McpToolTriggerBindingTests.cs
@@ -155,4 +155,42 @@ public class McpToolTriggerBindingTests
         Assert.Contains(param.Name!, binding.BindingDataContract.Keys);
         Assert.Contains("$return", binding.BindingDataContract.Keys);
     }
+
+    [Fact]
+    public async Task BindAsync_BindingData_IsCaseInsensitive()
+    {
+        var (binding, param) = CreateBinding();
+        CallToolExecutionContext executionContext = CreateExecutionContext();
+        var triggerData = await binding.BindAsync(executionContext, CreateValueBindingContext());
+
+        // Access using different casings
+        var ctxLower = triggerData.BindingData["mcptoolcontext"];
+        var ctxMixed = triggerData.BindingData["McpToolContext"];
+        var ctxUpper = triggerData.BindingData["MCPTOOLCONTEXT"];
+
+        Assert.Same(ctxLower, ctxMixed);
+        Assert.Same(ctxLower, ctxUpper);
+
+        // Parameter name
+        var paramValueOriginal = triggerData.BindingData[param.Name!];
+        var paramValueUpper = triggerData.BindingData[param.Name!.ToUpperInvariant()];
+        Assert.Same(paramValueOriginal, paramValueUpper);
+
+        // mcptoolargs and mcpsessionid
+        Assert.NotNull(triggerData.BindingData["McpToolArgs"]);
+        Assert.NotNull(triggerData.BindingData["McpSessionId"]);
+    }
+
+    [Fact]
+    public void BindingDataContract_IsCaseInsensitive()
+    {
+        var (binding, param) = CreateBinding();
+
+        // Verify case-insensitive ContainsKey behavior
+        Assert.True(binding.BindingDataContract.ContainsKey("McpToolContext"));
+        Assert.True(binding.BindingDataContract.ContainsKey("McpToolArgs"));
+        Assert.True(binding.BindingDataContract.ContainsKey("McpSessionId"));
+        Assert.True(binding.BindingDataContract.ContainsKey(param.Name!.ToUpperInvariant()));
+        Assert.True(binding.BindingDataContract.ContainsKey("$RETURN")); // different case
+    }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request improves the handling of binding data in the MCP tool trigger binding by ensuring case-insensitivity for both the binding data contract and the binding data dictionary. This aligns with the convention used by other extensions. Additionally, new unit tests have been added to verify this behavior.
