### PR TITLE
Fix readme: remove EnableMcpToolMetadata example

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/README.md
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/README.md
@@ -32,8 +32,6 @@ The above example will automatically expose the `name` and `snippet` parameters 
 
 Alternatively, you can define properties when creating your application as follows:
 ``` csharp
-builder.EnableMcpToolMetadata();
-
 // Define properties for the MCP tool:
 builder.ConfigureMcpTool("SaveSnippet")
     .WithProperty(SnippetNamePropertyName, PropertyType, SnippetNamePropertyDescription);


### PR DESCRIPTION
### Issue describing the changes in this PR

The EnableMcpToolMetadata API was removed in version 1.0.0 (PR #102) and is no longer required.

This pull request makes a minor documentation update to the `src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/README.md` file. The change removes the sample code line that enables MCP tool metadata, likely for clarity or to reflect updated usage.

For example, if you build using the current README, you will encounter the following error:

```
  Error CS1061: 'FunctionsApplicationBuilder' does
   not contain a definition for
  'EnableMcpToolMetadata' and no accessible
  extension method 'EnableMcpToolMetadata'
  accepting a first argument of type
  'FunctionsApplicationBuilder' could be found
  (are you missing a using directive or an
  assembly reference?)
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)
