### PR TITLE
Updating fluent tool definition APIs to support collection property types.

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Reflection;
 using Microsoft.Extensions.Options;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
@@ -1,14 +1,42 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Builder;
+using System.ComponentModel;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 
+/// <summary>
+/// Represents tool configuration options, including property definitions and their names, types, descriptions,
+/// and required status.
+/// </summary>
 public class ToolOptions
 {
+    [Obsolete($"Use the overload with an {nameof(McpToolPropertyType)} parameter.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddProperty(string name, string type, string description, bool required = false)
     {
         Properties.Add(new ToolProperty(name, type, description, required));
     }
 
+    /// <summary>
+    /// Adds a new property definition to the tool with the specified name, type, description, and required status.
+    /// </summary>
+    /// <param name="name">The name of the property to add. Cannot be null or empty.</param>
+    /// <param name="type">The type of the property, including information about whether it is an array.</param>
+    /// <param name="description">A description of the property's purpose or usage. Cannot be null.</param>
+    /// <param name="required">Indicates whether the property is required. Set to <see langword="true"/> if the property must be provided;
+    /// otherwise, <see langword="false"/>.</param>
+    public void AddProperty(string name, McpToolPropertyType type, string description, bool required = false)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentNullException.ThrowIfNull(type, nameof(type));
+
+        Properties.Add(new ToolProperty(name, type.TypeName, description, required, type.IsArray));
+    }
+
+    /// <summary>
+    /// Gets or sets the collection of properties that define the characteristics or configuration of the tool.
+    /// </summary>
     public required List<ToolProperty> Properties { get; set; } = [];
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
@@ -1,15 +1,42 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel;
 
 namespace Microsoft.Azure.Functions.Worker.Builder;
 
+/// <summary>
+/// Provides a fluent builder for configuring properties of an MCP tool within a Functions Worker application.
+/// </summary>
+/// <param name="builder">The application builder used to configure services and tool options.</param>
+/// <param name="toolName">The unique name of the tool to configure.</param>
 public sealed class McpToolBuilder(IFunctionsWorkerApplicationBuilder builder, string toolName)
 {
+    [Obsolete($"Use the overload with an {nameof(McpToolPropertyType)} parameter.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public McpToolBuilder WithProperty(string name, string type, string description, bool required = false)
     {
+        builder.Services.Configure<ToolOptions>(toolName, o => o.AddProperty(name, type, description, required));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a property definition to the tool configuration and returns the current builder instance for chaining.
+    /// </summary>
+    /// <param name="name">The name of the property to add. Cannot be null or empty.</param>
+    /// <param name="type">The type of the property, specifying how the value will be interpreted.</param>
+    /// <param name="description">A description of the property, used for documentation or help text. Cannot be null.</param>
+    /// <param name="required">Indicates whether the property is required. If <see langword="true"/>, the property must be provided by the
+    /// user.</param>
+    /// <returns>The current <see cref="McpToolBuilder"/> instance, enabling fluent configuration.</returns>
+    public McpToolBuilder WithProperty(string name, McpToolPropertyType type, string description, bool required = false)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentNullException.ThrowIfNull(type, nameof(type));
+
         builder.Services.Configure<ToolOptions>(toolName, o => o.AddProperty(name, type, description, required));
 
         return this;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyType.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpToolPropertyType.cs
@@ -1,25 +1,112 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Reflection;
+namespace Microsoft.Azure.Functions.Worker.Builder;
 
-internal sealed record McpToolPropertyType(string TypeName, bool IsArray = false)
+/// <summary>
+/// Represents the type information for a property used within the MCP tool, including its name and whether it is an
+/// array type.
+/// </summary>
+/// <param name="TypeName">The name of the property type. This value identifies the kind of data represented, such as "string", "number",
+/// "integer", "boolean", or "object".</param>
+/// <param name="IsArray">Indicates whether the property type represents an array. Specify <see langword="true"/> for array types; otherwise,
+/// <see langword="false"/>.</param>
+public sealed record McpToolPropertyType(string TypeName, bool IsArray = false)
 {
+    private const string StringTypeName = "string";
+    private const string ObjectTypeName = "object";
+    private const string NumberTypeName = "number";
+    private const string IntegerTypeName = "integer";
+    private const string BooleanTypeName = "boolean";
+
     private static McpToolPropertyType? _string;
+    private static McpToolPropertyType? _stringArray;
+
     private static McpToolPropertyType? _number;
+    private static McpToolPropertyType? _numberArray;
+
     private static McpToolPropertyType? _integer;
+    private static McpToolPropertyType? _integerArray;
+
     private static McpToolPropertyType? _boolean;
+    private static McpToolPropertyType? _booleanArray;
+
     private static McpToolPropertyType? _object;
+    private static McpToolPropertyType? _objectArray;
 
-    public static McpToolPropertyType String => _string ??= new("string");
+    /// <summary>
+    /// Gets a property type value that represents a string MCP property.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for string properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType String => _string ??= new(StringTypeName);
 
-    public static McpToolPropertyType Number => _number ??= new("number");
+    /// <summary>
+    /// Gets the property type representing an array of <see cref="String"/>.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for string arrays properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType StringArray => _stringArray ??= new(StringTypeName, true);
 
-    public static McpToolPropertyType Integer => _integer ??= new("integer");
+    /// <summary>
+    /// Gets a property type value that represents a number MCP property.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for number properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType Number => _number ??= new(NumberTypeName);
 
-    public static McpToolPropertyType Boolean => _boolean ??= new("boolean");
+    /// <summary>
+    /// Gets the property type representing an array of <see cref="Number"/>.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for number arrays properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType NumberArray => _numberArray ??= new(NumberTypeName, true);
 
-    public static McpToolPropertyType Object => _object ??= new("object");
+    /// <summary>
+    /// Gets a property type value that represents an integer MCP property.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for integer properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType Integer => _integer ??= new(IntegerTypeName);
 
+    /// <summary>
+    /// Gets the property type representing an array of <see cref="Integer"/>.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for integer arrays properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType IntegerArray => _integerArray ??= new(IntegerTypeName, true);
+
+    /// <summary>
+    /// Gets a property type value that represents a boolean MCP property type.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for boolean properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType Boolean => _boolean ??= new(BooleanTypeName);
+
+    /// <summary>
+    /// Gets the property type representing an array of <see cref="Boolean"/>.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for boolean arrays properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType BooleanArray => _booleanArray ??= new(BooleanTypeName, true);
+
+    /// <summary>
+    /// Gets a property type value that represents an object MCP property type.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for object properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType Object => _object ??= new(ObjectTypeName);
+
+    /// <summary>
+    /// Gets the property type representing an array of <see cref="Object"/>.
+    /// </summary>
+    /// <remarks>This property provides a reusable type definition for object arrays properties.
+    /// The returned type is immutable and can be shared across multiple components.</remarks>
+    public static McpToolPropertyType ObjectArray => _objectArray ??= new(ObjectTypeName, true);
+
+    /// <summary>
+    /// Returns a new instance of the property type representing an array of the current type.
+    /// </summary>
+    /// <returns>A <see cref="McpToolPropertyType"/> instance configured as an array of the current type.</returns>
     public McpToolPropertyType AsArray() => new(TypeName, true);
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/TypeExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/TypeExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Functions.Worker.Builder;
 using System.Collections;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Reflection;

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -11,3 +11,4 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp <version>
 
 - Fix argument type conversion logic in MCP input binding; now correctly handle Guid and DateTime types (#126)
+- Added support for collection/array property types in fluent tool definition APIs (#128)

--- a/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Worker.Extensions.Mcp.Tests;
+
+public class McpToolBuilderTests
+{
+    private static McpToolBuilder CreateBuilder(string toolName, out ServiceCollection services)
+    {
+        services = new ServiceCollection();
+        services.AddOptions();
+
+        var appBuilder = new Mock<IFunctionsWorkerApplicationBuilder>();
+        appBuilder.SetupGet(b => b.Services).Returns(services);
+
+        return new McpToolBuilder(appBuilder.Object, toolName);
+    }
+
+    [Fact]
+    public void WithProperty_AddsToolProperty()
+    {
+        var toolName = "myTool";
+        var builder = CreateBuilder(toolName, out var services);
+
+        builder.WithProperty("prop1", McpToolPropertyType.String, "desc1", required: true);
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get(toolName);
+
+        Assert.Single(options.Properties);
+        var p = options.Properties[0];
+        Assert.Equal("prop1", p.Name);
+        Assert.Equal("string", p.Type);
+        Assert.Equal("desc1", p.Description);
+        Assert.True(p.IsRequired);
+        Assert.False(p.IsArray);
+    }
+
+    [Fact]
+    public void WithProperty_ArrayType_AddsArrayFlag()
+    {
+        var toolName = "arrayTool";
+        var builder = CreateBuilder(toolName, out var services);
+
+        builder.WithProperty("numbers", McpToolPropertyType.Number.AsArray(), "numbers array");
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get(toolName);
+
+        Assert.Single(options.Properties);
+        Assert.True(options.Properties[0].IsArray);
+        Assert.Equal("number", options.Properties[0].Type);
+    }
+
+    [Fact]
+    public void WithProperty_Chaining_AddsMultipleProperties()
+    {
+        var toolName = "chainTool";
+        var builder = CreateBuilder(toolName, out var services);
+
+        builder
+            .WithProperty("id", McpToolPropertyType.Integer, "identifier", required: true)
+            .WithProperty("tags", McpToolPropertyType.String.AsArray(), "tags");
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get(toolName);
+
+        Assert.Equal(2, options.Properties.Count);
+
+        var id = options.Properties.First(p => p.Name == "id");
+        Assert.Equal("integer", id.Type);
+        Assert.True(id.IsRequired);
+        Assert.False(id.IsArray);
+
+        var tags = options.Properties.First(p => p.Name == "tags");
+        Assert.Equal("string", tags.Type);
+        Assert.False(tags.IsRequired);
+        Assert.True(tags.IsArray);
+    }
+
+    [Fact]
+    public void WithProperty_EmptyName_Throws()
+    {
+        var builder = CreateBuilder("tool", out _);
+        var ex = Assert.Throws<ArgumentException>(() =>
+            builder.WithProperty(string.Empty, McpToolPropertyType.Boolean, "desc"));
+
+        Assert.Equal("name", ex.ParamName);
+    }
+
+    [Fact]
+    public void WithProperty_NullType_Throws()
+    {
+        var builder = CreateBuilder("tool", out _);
+        var type = null as McpToolPropertyType;
+        var ex = Assert.Throws<ArgumentNullException>(() =>
+            builder.WithProperty("prop", type!, "desc"));
+
+        Assert.Equal("type", ex.ParamName);
+    }
+
+    [Fact]
+    public void Obsolete_WithProperty_StringOverload_AddsProperty()
+    {
+#pragma warning disable CS0618
+        var toolName = "legacyTool";
+        var builder = CreateBuilder(toolName, out var services);
+
+        builder.WithProperty("legacyProp", "string", "legacy description", required: true);
+#pragma warning restore CS0618
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get(toolName);
+
+        Assert.Single(options.Properties);
+        var p = options.Properties[0];
+        Assert.Equal("legacyProp", p.Name);
+        Assert.Equal("string", p.Type);
+        Assert.True(p.IsRequired);
+        Assert.False(p.IsArray); // legacy overload cannot set arrays
+    }
+
+    [Fact]
+    public void WithProperty_ReturnsSameBuilderInstance()
+    {
+        var builder = CreateBuilder("tool", out _);
+        var result = builder.WithProperty("p", McpToolPropertyType.Object, "desc");
+
+        Assert.Same(builder, result);
+    }
+}

--- a/test/Worker.Extensions.Mcp.Tests/McpToolPropertyTypeTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpToolPropertyTypeTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Builder;
+
+namespace Worker.Extensions.Mcp.Tests;
+
+public class McpToolPropertyTypeTests
+{
+    [Fact]
+    public void StaticProperties_ReturnExpectedValues()
+    {
+        Assert.Equal("string", McpToolPropertyType.String.TypeName);
+        Assert.False(McpToolPropertyType.String.IsArray);
+
+        Assert.Equal("number", McpToolPropertyType.Number.TypeName);
+        Assert.False(McpToolPropertyType.Number.IsArray);
+
+        Assert.Equal("integer", McpToolPropertyType.Integer.TypeName);
+        Assert.False(McpToolPropertyType.Integer.IsArray);
+
+        Assert.Equal("boolean", McpToolPropertyType.Boolean.TypeName);
+        Assert.False(McpToolPropertyType.Boolean.IsArray);
+
+        Assert.Equal("object", McpToolPropertyType.Object.TypeName);
+        Assert.False(McpToolPropertyType.Object.IsArray);
+    }
+
+    [Fact]
+    public void StaticArrayProperties_ReturnExpectedValues()
+    {
+        Assert.Equal("string", McpToolPropertyType.StringArray.TypeName);
+        Assert.True(McpToolPropertyType.StringArray.IsArray);
+
+        Assert.Equal("number", McpToolPropertyType.NumberArray.TypeName);
+        Assert.True(McpToolPropertyType.NumberArray.IsArray);
+
+        Assert.Equal("integer", McpToolPropertyType.IntegerArray.TypeName);
+        Assert.True(McpToolPropertyType.IntegerArray.IsArray);
+
+        Assert.Equal("boolean", McpToolPropertyType.BooleanArray.TypeName);
+        Assert.True(McpToolPropertyType.BooleanArray.IsArray);
+
+        Assert.Equal("object", McpToolPropertyType.ObjectArray.TypeName);
+        Assert.True(McpToolPropertyType.ObjectArray.IsArray);
+    }
+
+    [Fact]
+    public void StaticProperties_AreSingletonInstances()
+    {
+        Assert.Same(McpToolPropertyType.String, McpToolPropertyType.String);
+        Assert.Same(McpToolPropertyType.Number, McpToolPropertyType.Number);
+        Assert.Same(McpToolPropertyType.Integer, McpToolPropertyType.Integer);
+        Assert.Same(McpToolPropertyType.Boolean, McpToolPropertyType.Boolean);
+        Assert.Same(McpToolPropertyType.Object, McpToolPropertyType.Object);
+
+        Assert.Same(McpToolPropertyType.StringArray, McpToolPropertyType.StringArray);
+        Assert.Same(McpToolPropertyType.NumberArray, McpToolPropertyType.NumberArray);
+        Assert.Same(McpToolPropertyType.IntegerArray, McpToolPropertyType.IntegerArray);
+        Assert.Same(McpToolPropertyType.BooleanArray, McpToolPropertyType.BooleanArray);
+        Assert.Same(McpToolPropertyType.ObjectArray, McpToolPropertyType.ObjectArray);
+    }
+
+    [Fact]
+    public void Equality_ByValue_NotByReference()
+    {
+        var expected = new McpToolPropertyType("string");
+        Assert.Equal(expected, McpToolPropertyType.String);
+        Assert.NotSame(expected, McpToolPropertyType.String);
+
+        var expectedArray = new McpToolPropertyType("string", true);
+        Assert.Equal(expectedArray, McpToolPropertyType.StringArray);
+        Assert.NotSame(expectedArray, McpToolPropertyType.StringArray);
+    }
+
+    [Fact]
+    public void AsArray_OnNonArray_ReturnsArrayWithSameTypeName()
+    {
+        var original = McpToolPropertyType.Integer;
+        var arrayVersion = original.AsArray();
+
+        Assert.Equal(original.TypeName, arrayVersion.TypeName);
+        Assert.True(arrayVersion.IsArray);
+        Assert.NotSame(original, arrayVersion);
+        Assert.Equal(new McpToolPropertyType("integer", true), arrayVersion);
+    }
+
+    [Fact]
+    public void AsArray_OnArray_ReturnsNewArrayInstance()
+    {
+        var arrayOriginal = McpToolPropertyType.IntegerArray;
+        var arrayAgain = arrayOriginal.AsArray();
+
+        Assert.True(arrayOriginal.IsArray);
+        Assert.True(arrayAgain.IsArray);
+        Assert.Equal(arrayOriginal.TypeName, arrayAgain.TypeName);
+        Assert.NotSame(arrayOriginal, arrayAgain); // new instance each call
+        Assert.Equal(arrayOriginal, arrayAgain);   // value equality
+    }
+
+    [Theory]
+    [InlineData("string", false)]
+    [InlineData("string", true)]
+    [InlineData("number", false)]
+    [InlineData("number", true)]
+    [InlineData("integer", false)]
+    [InlineData("integer", true)]
+    [InlineData("boolean", false)]
+    [InlineData("boolean", true)]
+    [InlineData("object", false)]
+    [InlineData("object", true)]
+    public void NewInstances_WithSameValues_AreValueEqual(string typeName, bool isArray)
+    {
+        var a = new McpToolPropertyType(typeName, isArray);
+        var b = new McpToolPropertyType(typeName, isArray);
+
+        Assert.Equal(a, b);
+        Assert.NotSame(a, b);
+    }
+}

--- a/test/Worker.Extensions.Mcp.Tests/TypeExtensionsTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/TypeExtensionsTests.cs
@@ -1,30 +1,31 @@
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Reflection;
 
 namespace Worker.Extensions.Mcp.Tests;
 
 public class TypeExtensionsTests
 {
-    public static IEnumerable<object[]> PocoTestCases => new List<object[]>
-    {
-        new object[] { typeof(PocoClass), true },
-        new object[] { typeof(EmptyClass), true },
-        new object[] { typeof(ClassWithFieldsOnly), true },
-        new object[] { typeof(NestedPocoClass), true },
-        new object[] { typeof(PocoWithPrivateFields), true },
-        new object[] { typeof(GenericClass<string>), true },
-        new object[] { typeof(ClassWithStaticCtor), true },
-        new object[] { typeof(ClassWithInitOnly), true },
+    public static IEnumerable<object[]> PocoTestCases =>
+    [
+        [typeof(PocoClass), true],
+        [typeof(EmptyClass), true],
+        [typeof(ClassWithFieldsOnly), true],
+        [typeof(NestedPocoClass), true],
+        [typeof(PocoWithPrivateFields), true],
+        [typeof(GenericClass<string>), true],
+        [typeof(ClassWithStaticCtor), true],
+        [typeof(ClassWithInitOnly), true],
 
-        new object[] { typeof(string), false },
-        new object[] { typeof(AbstractClass), false },
-        new object[] { typeof(ITest), false },
-        new object[] { typeof(CollectionClass), false },
-        new object[] { typeof(NoDefaultCtor), false },
-        new object[] { typeof(GenericClass<>), false },
-        new object[] { typeof(StructExample), false },
-        new object[] { typeof(RecordExample), false },
-        new object[] { typeof(CollectionDerived), false }
-    };
+        [typeof(string), false],
+        [typeof(AbstractClass), false],
+        [typeof(ITest), false],
+        [typeof(CollectionClass), false],
+        [typeof(NoDefaultCtor), false],
+        [typeof(GenericClass<>), false],
+        [typeof(StructExample), false],
+        [typeof(RecordExample), false],
+        [typeof(CollectionDerived), false]
+    ];
 
     [Theory]
     [MemberData(nameof(PocoTestCases))]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request introduces a new, strongly-typed approach for defining MCP tool property types, replacing string-based type definitions with the new `McpToolPropertyType`. It updates the builder and configuration APIs to support this type-safe mechanism, adds XML documentation, and provides unit tests to validate the new functionality. The changes also include minor refactorings for clarity and maintainability.