### PR TITLE
Remove preview warning for Azure Functions MCP extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ In addition to the host extension which supports all stacks, this repository als
 
 ## Instructions
 
-> [!IMPORTANT]
-> The Azure Functions MCP extension is currently in preview. You can expect changes to the trigger and binding APIs prior to the extension becoming generally available.
-> You should avoid using preview extensions in production apps.
-
 To get started with the extension, please see the following samples:
 
 | Language (Stack) | Repo Location |


### PR DESCRIPTION
Removed notes about the Azure Functions MCP extension being in preview and usage in production.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

