### PR TITLE
Updating McpInputConversionHelper to handle string target conversions

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/McpInputConversionHelper.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/McpInputConversionHelper.cs
@@ -91,6 +91,12 @@ internal static class McpInputConversionHelper
             return typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
         }
 
+        // As a fallback, if the target type is a string, try ToString on the value
+        if (targetType == typeof(string))
+        {
+            return Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+
         return null;
     }
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -15,3 +15,4 @@
 - Added support for collection/array property types in fluent tool definition APIs (#128)
 - Added support for enum property types (#131)
 - Updated MCP SDK reference to 0.4.0-preview.3
+- Updating McpInputConversionHelper to handle string target conversions (#145)

--- a/test/TestAppIsolated/ToolFunctions.cs
+++ b/test/TestAppIsolated/ToolFunctions.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
 using Microsoft.Azure.Functions.Worker;
@@ -30,7 +31,7 @@ public class TestFunction
         var entityToGreet = name ?? "world";
         return $"""
             Hello, {entityToGreet}! Job: {job ?? JobType.Unemployed} | Age: {age} | Happy? {isHappy}.
-            Attributes: {(attributes.Any() ? string.Join(", ", attributes) : "(none)")}
+            Attributes: {(attributes is ICollection { Count: > 0} ? string.Join(", ", attributes) : "(none)")}
             """;
     }
 

--- a/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
@@ -119,6 +119,25 @@ public class McpInputConversionHelperTests
         Assert.Equal(expected, result);
     }
 
+    [Theory]
+    [MemberData(nameof(StringConversionValues))]
+    public void TryConvertToTargetType_SupportedTypeToString_Success(object input, string expectedResult)
+    {
+        var guid = Guid.NewGuid();
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(string), out var result);
+        Assert.True(success);
+        Assert.Equal(expectedResult, result);
+    }
+
+    public static IEnumerable<object[]> StringConversionValues()
+    {
+        return [
+            [Guid.Parse("E3A69220-1099-483A-942F-4877CCB80E21"), "e3a69220-1099-483a-942f-4877ccb80e21"],
+            [DateTime.Parse("01/01/2025"), "01/01/2025 00:00:00"],
+            [DateTimeOffset.Parse("01/01/2025 00:00:00 +00:00"), "01/01/2025 00:00:00 +00:00"]
+        ];
+    }
+
     [TypeConverter(typeof(TestPocoConverter))]
     private class TestPoco
     {


### PR DESCRIPTION
Updating McpInputConversionHelper to handle conversions into an appropriate string representation, addressing issues with values that are "stringified" in the incoming payload and converted to other types as part of the deserialization process.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #129 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

