### PR TITLE
Fix incorrect ArgumentNullException.ThrowIfNull usage

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultToolRegistry.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/DefaultToolRegistry.cs
@@ -13,7 +13,7 @@ internal sealed class DefaultToolRegistry : IToolRegistry
 
     public void Register(IMcpTool tool)
     {
-        ArgumentNullException.ThrowIfNull(nameof(tool));
+        ArgumentNullException.ThrowIfNull(tool);
 
         if (!_tools.TryAdd(tool.Name, tool))
         {
@@ -23,7 +23,7 @@ internal sealed class DefaultToolRegistry : IToolRegistry
 
     public bool TryGetTool(string name, [NotNullWhen(true)] out IMcpTool? tool)
     {
-        ArgumentNullException.ThrowIfNull(nameof(name));
+        ArgumentNullException.ThrowIfNull(name);
         return _tools.TryGetValue(name, out tool);
     }
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/McpWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/McpWebJobsBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class McpWebJobsBuilderExtensions
     /// <param name="builder">The <see cref="IWebJobsBuilder"/> to configure.</param>
     public static IWebJobsBuilder AddMcp(this IWebJobsBuilder builder)
     {
-        ArgumentNullException.ThrowIfNull(nameof(builder));
+        ArgumentNullException.ThrowIfNull(builder);
 
         // Uncomment the line below to register the endpoints as functions.
         //builder.Services.AddSingleton<IFunctionProvider, McpFunctionProvider>();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

n/a

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Corrects ArgumentNullException.ThrowIfNull to check parameter values instead of nameof() string literals in DefaultToolRegistry and McpWebJobsBuilderExtensions.
