### PR TITLE
Skip .Sdk package in the main release CI

### DIFF
--- a/eng/ci/templates/jobs/release-packages.yml
+++ b/eng/ci/templates/jobs/release-packages.yml
@@ -50,6 +50,7 @@ extends:
           isProduction: true
           approvers: '[internal]\Azure Functions Core'
           stagingFeed: public/pre-release
+          packages: '**/*.nupkg;!**/*.symbols.nupkg;!**/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk.*.nupkg'
           artifact:
             name: ${{ parameters.artifactName }}
             pipeline: build


### PR DESCRIPTION
Since we now have an independent pipeline for the .Sdk package, we need to ignore it in the main release pipeline