### PR TITLE
 Add MCP prompt SDK support for rich return types

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/McpConstants.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/McpConstants.cs
@@ -23,4 +23,10 @@ internal sealed class McpConstants
         public const string Resource = "resource";
         public const string ResourceLink = "resource_link";
     }
+
+    internal sealed class PromptResultContentTypes
+    {
+        public const string GetPromptResult = "get_prompt_result";
+        public const string PromptMessages = "prompt_messages";
+    }
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptResult.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Functions.Extensions.Mcp;
+
+/// <summary>
+/// Host-side counterpart of the worker SDK's <c>McpPromptResult</c> envelope.
+/// Carries a serialized payload (e.g. a <c>GetPromptResult</c> or list of
+/// <c>PromptMessage</c>) along with a <see cref="Type"/> discriminator describing
+/// how to deserialize <see cref="Content"/>.
+/// </summary>
+internal sealed class McpPromptResult
+{
+    /// <summary>
+    /// The serialized inner payload.
+    /// </summary>
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// Discriminator describing the shape of <see cref="Content"/>.
+    /// </summary>
+    public required string Type { get; init; }
+}

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptTriggerAttribute.cs
@@ -43,4 +43,13 @@ public sealed class McpPromptTriggerAttribute(string promptName) : Attribute
     /// Gets or sets the JSON representation of the prompt icons.
     /// </summary>
     public string? Icons { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the worker is wrapping prompt return values in the SDK's
+    /// <c>McpPromptResult</c> envelope. When true, the host expects an envelope and
+    /// uses <see cref="PromptReturnValueBinder"/> to unwrap it. When false (default),
+    /// the host treats the return value as a raw string via
+    /// <see cref="SimplePromptReturnValueBinder"/>.
+    /// </summary>
+    public bool UseResultSchema { get; set; } = false;
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptTriggerBinding.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptTriggerBinding.cs
@@ -85,7 +85,9 @@ internal sealed class McpPromptTriggerBinding : ITriggerBinding
         }
 
         IValueProvider valueProvider = new ObjectValueProvider(triggerValue, _triggerParameter.ParameterType);
-        IValueBinder returnValueBinder = new PromptReturnValueBinder(executionContext);
+        IValueBinder returnValueBinder = _promptAttribute.UseResultSchema
+            ? new PromptReturnValueBinder(executionContext)
+            : new SimplePromptReturnValueBinder(executionContext);
 
         var data = new TriggerData(valueProvider, bindingData)
         {

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/PromptReturnValueBinder.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/PromptReturnValueBinder.cs
@@ -4,10 +4,18 @@
 using System.Text.Json;
 using Microsoft.Azure.Functions.Extensions.Mcp.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp;
 
+/// <summary>
+/// Return value binder used when the worker SDK middleware wraps prompt results
+/// in an <see cref="McpPromptResult"/> envelope. Unwraps the envelope and
+/// deserializes the inner payload based on the envelope's <c>Type</c> discriminator,
+/// so any successfully deserialized payload — including empty results — round-trips
+/// without shape-sniffing.
+/// </summary>
 internal sealed class PromptReturnValueBinder(GetPromptExecutionContext executionContext) : IValueBinder
 {
     public Type Type { get; } = typeof(object);
@@ -20,65 +28,60 @@ internal sealed class PromptReturnValueBinder(GetPromptExecutionContext executio
             return Task.CompletedTask;
         }
 
-        if (value is string stringValue)
+        if (value is not string jsonString)
         {
-            // Try to deserialize as GetPromptResult JSON from worker
-            if (TryDeserializeGetPromptResult(stringValue, out var promptResult))
-            {
-                executionContext.SetResult(promptResult);
-                return Task.CompletedTask;
-            }
-
-            // Otherwise treat as a single user text message
-            var result = new GetPromptResult
-            {
-                Messages =
-                [
-                    new PromptMessage
-                    {
-                        Role = Role.User,
-                        Content = new TextContentBlock { Text = stringValue }
-                    }
-                ]
-            };
-
-            executionContext.SetResult(result);
-            return Task.CompletedTask;
+            throw new ArgumentException("Expected JSON string.", nameof(value));
         }
 
-        throw new InvalidOperationException(
-            $"Unsupported return type for prompt: {value.GetType().Name}. Expected string.");
-    }
+        McpPromptResult envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<McpPromptResult>(jsonString, McpJsonSerializerOptions.DefaultOptions)
+                ?? throw new InvalidOperationException("The function return value could not be deserialized to a valid McpPromptResult.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("The function return value could not be deserialized to a valid McpPromptResult.", ex);
+        }
 
-    public Task<object> GetValueAsync()
-    {
-        throw new NotSupportedException();
-    }
-
-    public string ToInvokeString()
-    {
-        return string.Empty;
-    }
-
-    private static bool TryDeserializeGetPromptResult(string jsonString, out GetPromptResult result)
-    {
-        result = null!;
+        if (envelope.Content is not { } content)
+        {
+            throw new InvalidOperationException("McpPromptResult.Content was null; cannot process prompt result.");
+        }
 
         try
         {
-            var deserialized = JsonSerializer.Deserialize<GetPromptResult>(jsonString, McpJsonSerializerOptions.DefaultOptions);
-
-            if (deserialized?.Messages is { Count: > 0 } || deserialized?.Description is not null)
-            {
-                result = deserialized;
-                return true;
-            }
-
-            return false;
+            executionContext.SetResult(ProcessMcpPromptResult(envelope.Type, content));
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            return false;
+            throw new InvalidOperationException($"Failed to deserialize content for type '{envelope.Type}'.", ex);
         }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<object> GetValueAsync() => throw new NotSupportedException();
+
+    public string ToInvokeString() => string.Empty;
+
+    private static GetPromptResult ProcessMcpPromptResult(string type, string content)
+    {
+        if (string.Equals(type, McpConstants.PromptResultContentTypes.GetPromptResult, StringComparison.OrdinalIgnoreCase))
+        {
+            return JsonSerializer.Deserialize<GetPromptResult>(content, McpJsonUtilities.DefaultOptions)
+                ?? throw new InvalidOperationException("Failed to deserialize GetPromptResult from McpPromptResult content.");
+        }
+
+        if (string.Equals(type, McpConstants.PromptResultContentTypes.PromptMessages, StringComparison.OrdinalIgnoreCase))
+        {
+            var messages = JsonSerializer.Deserialize<IList<PromptMessage>>(content, McpJsonUtilities.DefaultOptions)
+                ?? throw new InvalidOperationException("Failed to deserialize PromptMessage list from McpPromptResult content.");
+
+            return new GetPromptResult { Messages = messages };
+        }
+
+        throw new InvalidOperationException($"Unknown McpPromptResult type: '{type}'.");
     }
 }
+

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/SimplePromptReturnValueBinder.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/SimplePromptReturnValueBinder.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using ModelContextProtocol.Protocol;
+
+namespace Microsoft.Azure.Functions.Extensions.Mcp;
+
+/// <summary>
+/// Return value binder used when the worker is not wrapping prompt results in the
+/// SDK <see cref="McpPromptResult"/> envelope (e.g. in-process workers, or isolated
+/// workers without the SDK middleware). Treats the raw return value as text and
+/// wraps it in a single-message <see cref="GetPromptResult"/>.
+/// </summary>
+internal sealed class SimplePromptReturnValueBinder(GetPromptExecutionContext executionContext) : IValueBinder
+{
+    public Type Type { get; } = typeof(object);
+
+    public Task SetValueAsync(object value, CancellationToken cancellationToken)
+    {
+        if (value is null)
+        {
+            executionContext.SetResult(new GetPromptResult { Messages = [] });
+            return Task.CompletedTask;
+        }
+
+        var text = value.ToString() ?? string.Empty;
+
+        executionContext.SetResult(new GetPromptResult
+        {
+            Messages =
+            [
+                new PromptMessage
+                {
+                    Role = Role.User,
+                    Content = new TextContentBlock { Text = text }
+                }
+            ]
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task<object> GetValueAsync() => throw new NotSupportedException();
+
+    public string ToInvokeString() => string.Empty;
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
@@ -11,6 +11,7 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
 {
     public string Name => nameof(McpUseResultSchemaTransformer);
     private const string McpToolTriggerBindingType = "mcpToolTrigger";
+    private const string McpPromptTriggerBindingType = "mcpPromptTrigger";
     private const string UseResultSchemaFlag = "useResultSchema";
 
     public void Transform(IList<IFunctionMetadata> original)
@@ -44,21 +45,29 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
                     continue;
                 }
 
-                // Check binding type
-                if (jsonObject.TryGetPropertyValue(BindingType, out var typeNode))
+                if (!jsonObject.TryGetPropertyValue(BindingType, out var typeNode))
                 {
-                    var bindingType = typeNode?.ToString();
-                    if (string.Equals(bindingType, McpToolTriggerBindingType, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Only set useResultSchema to true if there are NO output bindings
-                        // When output bindings exist, we want SimpleToolReturnValueBinder to handle the raw value
-                        if (!hasOutputBindings)
-                        {
-                            jsonObject[UseResultSchemaFlag] = true;
-                        }
-                        function.RawBindings[i] = jsonObject.ToJsonString();
-                    }
+                    continue;
                 }
+
+                var bindingType = typeNode?.ToString();
+                bool isMcpTrigger =
+                    string.Equals(bindingType, McpToolTriggerBindingType, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(bindingType, McpPromptTriggerBindingType, StringComparison.OrdinalIgnoreCase);
+
+                if (!isMcpTrigger)
+                {
+                    continue;
+                }
+
+                // Only set useResultSchema to true if there are NO output bindings.
+                // When output bindings exist, we want the simple binder to handle the raw value.
+                if (!hasOutputBindings)
+                {
+                    jsonObject[UseResultSchemaFlag] = true;
+                }
+
+                function.RawBindings[i] = jsonObject.ToJsonString();
             }
         }
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk;
 internal static class Constants
 {
     public const string ToolInvocationContextKey = "ToolInvocationContext";
+    public const string PromptInvocationContextKey = "PromptInvocationContext";
 
     public const string MultiContentResult = "multi_content_result";
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
@@ -8,11 +8,14 @@ internal static class Constants
     public const string ToolInvocationContextKey = "ToolInvocationContext";
     public const string PromptInvocationContextKey = "PromptInvocationContext";
 
+    // Tool result content types
+    public const string CallToolResultType = "call_tool_result";
     public const string MultiContentResult = "multi_content_result";
-
     public const string TextContextResult = "text";
 
-    public const string CallToolResultType = "call_tool_result";
+    // Prompt result content types
+    public const string GetPromptResultType = "get_prompt_result";
+    public const string PromptMessagesType = "prompt_messages";
 
     // Binding JSON property keys
     public const string BindingType = "type";

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/DependencyInjection/HostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/DependencyInjection/HostBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class McpSdkHostBuilderExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IFunctionMetadataTransformer, McpUseResultSchemaTransformer>());
 
         builder.UseMiddleware<FunctionsMcpToolResultMiddleware>();
+        builder.UseMiddleware<FunctionsMcpPromptResultMiddleware>();
 
         return builder;
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
@@ -10,14 +10,13 @@ using ModelContextProtocol.Protocol;
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 
 /// <summary>
-/// Normalizes the worker's prompt-function return value into a serialized
-/// <see cref="GetPromptResult"/> JSON string for the host binder to consume.
+/// Wraps the worker's prompt-function return value into an <see cref="McpPromptResult"/>
+/// envelope (Type + serialized Content) for the host binder to deserialize.
 /// </summary>
 /// <remarks>
-/// Unlike <see cref="FunctionsMcpToolResultMiddleware"/>, no envelope is needed:
-/// every supported prompt return type collapses without information loss into
-/// the MCP protocol's own <see cref="GetPromptResult"/> shape, which is also
-/// the natural cross-language wire contract.
+/// Mirrors <see cref="FunctionsMcpToolResultMiddleware"/>. The envelope's <c>Type</c>
+/// discriminator lets the host accept any successfully deserialized payload — including
+/// empty <c>GetPromptResult</c> values — without shape-sniffing the JSON.
 /// </remarks>
 internal class FunctionsMcpPromptResultMiddleware : IFunctionsWorkerMiddleware
 {
@@ -52,32 +51,56 @@ internal class FunctionsMcpPromptResultMiddleware : IFunctionsWorkerMiddleware
             return;
         }
 
-        GetPromptResult promptResult = functionResult switch
+        string type;
+        string content;
+
+        switch (functionResult)
         {
-            GetPromptResult result => result,
-            PromptMessage message => new GetPromptResult { Messages = [message] },
-            IList<PromptMessage> messages => new GetPromptResult { Messages = messages },
-            string text => new GetPromptResult
-            {
-                Messages = [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = text } }]
-            },
-            _ => new GetPromptResult
-            {
-                Messages =
-                [
-                    new PromptMessage
+            case GetPromptResult getPromptResult:
+                type = Constants.GetPromptResultType;
+                content = JsonSerializer.Serialize(getPromptResult, McpJsonUtilities.DefaultOptions);
+                break;
+
+            case PromptMessage promptMessage:
+                type = Constants.PromptMessagesType;
+                content = JsonSerializer.Serialize(new[] { promptMessage }, McpJsonUtilities.DefaultOptions);
+                break;
+
+            case IList<PromptMessage> messages:
+                type = Constants.PromptMessagesType;
+                content = JsonSerializer.Serialize(messages, McpJsonUtilities.DefaultOptions);
+                break;
+
+            default:
+                // Strings and other arbitrary types collapse into a single User text message.
+                string text = functionResult is string s
+                    ? s
+                    : JsonSerializer.Serialize(functionResult, McpJsonUtilities.DefaultOptions);
+
+                type = Constants.GetPromptResultType;
+                content = JsonSerializer.Serialize(
+                    new GetPromptResult
                     {
-                        Role = Role.User,
-                        Content = new TextContentBlock
-                        {
-                            Text = JsonSerializer.Serialize(functionResult, McpJsonUtilities.DefaultOptions)
-                        }
-                    }
-                ]
-            }
+                        Messages =
+                        [
+                            new PromptMessage
+                            {
+                                Role = Role.User,
+                                Content = new TextContentBlock { Text = text }
+                            }
+                        ]
+                    },
+                    McpJsonUtilities.DefaultOptions);
+                break;
+        }
+
+        var envelope = new McpPromptResult
+        {
+            Type = type,
+            Content = content
         };
 
-        _resultAccessor.SetResult(context, JsonSerializer.Serialize(promptResult, McpJsonUtilities.DefaultOptions));
+        _resultAccessor.SetResult(context, JsonSerializer.Serialize(envelope, McpJsonContext.Default.McpPromptResult));
     }
 
     private static bool IsMcpPromptInvocation(FunctionContext context)

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+
+/// <summary>
+/// Normalizes the worker's prompt-function return value into a serialized
+/// <see cref="GetPromptResult"/> JSON string for the host binder to consume.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="FunctionsMcpToolResultMiddleware"/>, no envelope is needed:
+/// every supported prompt return type collapses without information loss into
+/// the MCP protocol's own <see cref="GetPromptResult"/> shape, which is also
+/// the natural cross-language wire contract.
+/// </remarks>
+internal class FunctionsMcpPromptResultMiddleware : IFunctionsWorkerMiddleware
+{
+    private readonly IFunctionResultAccessor _resultAccessor;
+
+    public FunctionsMcpPromptResultMiddleware(IFunctionResultAccessor? resultAccessor = null)
+    {
+        _resultAccessor = resultAccessor ?? new DefaultFunctionResultAccessor();
+    }
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        await next(context);
+
+        if (!IsMcpPromptInvocation(context))
+        {
+            return;
+        }
+
+        var functionResult = _resultAccessor.GetResult(context);
+
+        if (functionResult is null)
+        {
+            return;
+        }
+
+        // If there are output bindings, don't wrap the result - let it flow to the output binding.
+        if (HasOutputBindings(context))
+        {
+            return;
+        }
+
+        GetPromptResult promptResult = functionResult switch
+        {
+            GetPromptResult result => result,
+            PromptMessage message => new GetPromptResult { Messages = [message] },
+            IList<PromptMessage> messages => new GetPromptResult { Messages = messages },
+            string text => new GetPromptResult
+            {
+                Messages = [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = text } }]
+            },
+            _ => new GetPromptResult
+            {
+                Messages =
+                [
+                    new PromptMessage
+                    {
+                        Role = Role.User,
+                        Content = new TextContentBlock
+                        {
+                            Text = JsonSerializer.Serialize(functionResult, McpJsonUtilities.DefaultOptions)
+                        }
+                    }
+                ]
+            }
+        };
+
+        _resultAccessor.SetResult(context, JsonSerializer.Serialize(promptResult, McpJsonUtilities.DefaultOptions));
+    }
+
+    private static bool IsMcpPromptInvocation(FunctionContext context)
+    {
+        return context.Items.ContainsKey(Constants.PromptInvocationContextKey);
+    }
+
+    private static bool HasOutputBindings(FunctionContext context)
+    {
+        return context.FunctionDefinition.OutputBindings.Any();
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/FunctionsMiddleware/FunctionsMcpPromptResultMiddleware.cs
@@ -71,6 +71,11 @@ internal class FunctionsMcpPromptResultMiddleware : IFunctionsWorkerMiddleware
                 content = JsonSerializer.Serialize(messages, McpJsonUtilities.DefaultOptions);
                 break;
 
+            case IEnumerable<PromptMessage> messageSequence:
+                type = Constants.PromptMessagesType;
+                content = JsonSerializer.Serialize(messageSequence.ToList(), McpJsonUtilities.DefaultOptions);
+                break;
+
             default:
                 // Strings and other arbitrary types collapse into a single User text message.
                 string text = functionResult is string s

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/McpJsonContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/McpJsonContext.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 
 [JsonSourceGenerationOptions(WriteIndented = false, PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(McpToolResult))]
+[JsonSerializable(typeof(McpPromptResult))]
 internal sealed partial class McpJsonContext : JsonSerializerContext
 {
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/McpPromptResult.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/McpPromptResult.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+
+/// <summary>
+/// Envelope used by the worker SDK middleware to carry a prompt function's
+/// return value across the worker/host boundary. Mirrors <see cref="McpToolResult"/>
+/// so the host can deterministically deserialize the inner payload based on
+/// <see cref="Type"/>, without inspecting the payload shape.
+/// </summary>
+internal sealed class McpPromptResult
+{
+    /// <summary>
+    /// The serialized inner payload (e.g. a <c>GetPromptResult</c> or list of <c>PromptMessage</c>).
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// Discriminator describing the shape of <see cref="Content"/>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+}

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -14,6 +14,7 @@
 
 - Validate required prompt arguments (#244)
 - Added output schema support on the tool trigger (#245)
+- Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0-preview.1
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -75,3 +75,4 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
 - Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.2.0 (#222)
+- Add support for strongly-typed prompt trigger return types such as `GetPromptResult` and `PromptMessages` (#212)

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -76,4 +76,4 @@
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
 - Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.2.0 (#222)
-- Add support for strongly-typed prompt trigger return types such as `GetPromptResult` and `PromptMessages` (#212)
+- Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)

--- a/test/Extensions.Mcp.Tests/PromptReturnValueBinderTests.cs
+++ b/test/Extensions.Mcp.Tests/PromptReturnValueBinderTests.cs
@@ -89,14 +89,11 @@ public class PromptReturnValueBinderTests
     }
 
     [Fact]
-    public async Task SetValueAsync_WithJsonWithoutMessagesField_DeserializesAsEmptyPromptResult()
+    public async Task SetValueAsync_WithJsonHavingDescriptionOnly_DeserializesAsPromptResult()
     {
         var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
         var binder = new PromptReturnValueBinder(executionContext);
 
-        // JSON that can deserialize to GetPromptResult but has no messages field.
-        // GetPromptResult initializes Messages to empty list by default,
-        // so this will successfully deserialize with empty messages.
         var json = """{"description": "some description"}""";
         await binder.SetValueAsync(json, CancellationToken.None);
 
@@ -105,6 +102,21 @@ public class PromptReturnValueBinderTests
         Assert.NotNull(result.Messages);
         Assert.Empty(result.Messages);
         Assert.Equal("some description", result.Description);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithEmptyString_WrapsAsUserMessage()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        await binder.SetValueAsync("", CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Single(result.Messages);
+        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
+        Assert.Equal("", content.Text);
     }
 
     [Fact]
@@ -136,20 +148,5 @@ public class PromptReturnValueBinderTests
         var binder = new PromptReturnValueBinder(executionContext);
 
         Assert.Equal(string.Empty, binder.ToInvokeString());
-    }
-
-    [Fact]
-    public async Task SetValueAsync_WithEmptyString_WrapsAsUserMessage()
-    {
-        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
-        var binder = new PromptReturnValueBinder(executionContext);
-
-        await binder.SetValueAsync("", CancellationToken.None);
-
-        var result = await executionContext.ResultTask;
-        Assert.NotNull(result);
-        Assert.Single(result.Messages);
-        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
-        Assert.Equal("", content.Text);
     }
 }

--- a/test/Extensions.Mcp.Tests/PromptReturnValueBinderTests.cs
+++ b/test/Extensions.Mcp.Tests/PromptReturnValueBinderTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.Azure.Functions.Extensions.Mcp.Serialization;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
@@ -23,113 +24,139 @@ public class PromptReturnValueBinderTests
     }
 
     [Fact]
-    public async Task SetValueAsync_WithPlainString_WrapsAsUserMessage()
+    public async Task SetValueAsync_WithGetPromptResultEnvelope_DeserializesInner()
     {
         var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
         var binder = new PromptReturnValueBinder(executionContext);
 
-        await binder.SetValueAsync("Please review this code", CancellationToken.None);
-
-        var result = await executionContext.ResultTask;
-        Assert.NotNull(result);
-        Assert.Single(result.Messages);
-        Assert.Equal(Role.User, result.Messages[0].Role);
-        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
-        Assert.Equal("Please review this code", content.Text);
-    }
-
-    [Fact]
-    public async Task SetValueAsync_WithGetPromptResultJson_DeserializesDirectly()
-    {
-        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
-        var binder = new PromptReturnValueBinder(executionContext);
-
-        var getPromptResult = new GetPromptResult
+        var inner = new GetPromptResult
         {
             Description = "Test prompt",
             Messages =
             [
-                new PromptMessage
-                {
-                    Role = Role.User,
-                    Content = new TextContentBlock { Text = "User message" }
-                },
-                new PromptMessage
-                {
-                    Role = Role.Assistant,
-                    Content = new TextContentBlock { Text = "Assistant message" }
-                }
+                new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = "User message" } },
+                new PromptMessage { Role = Role.Assistant, Content = new TextContentBlock { Text = "Assistant message" } }
             ]
         };
 
-        var json = JsonSerializer.Serialize(getPromptResult, McpJsonSerializerOptions.DefaultOptions);
-        await binder.SetValueAsync(json, CancellationToken.None);
+        await binder.SetValueAsync(SerializeEnvelope(McpConstants.PromptResultContentTypes.GetPromptResult, inner), CancellationToken.None);
 
         var result = await executionContext.ResultTask;
         Assert.NotNull(result);
+        Assert.Equal("Test prompt", result.Description);
         Assert.Equal(2, result.Messages.Count);
         Assert.Equal(Role.User, result.Messages[0].Role);
         Assert.Equal(Role.Assistant, result.Messages[1].Role);
     }
 
     [Fact]
-    public async Task SetValueAsync_WithInvalidJson_WrapsAsUserMessage()
+    public async Task SetValueAsync_WithEmptyGetPromptResultEnvelope_PreservesEmpty()
     {
         var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
         var binder = new PromptReturnValueBinder(executionContext);
 
-        await binder.SetValueAsync("not a json { string", CancellationToken.None);
+        var inner = new GetPromptResult { Messages = [] };
+
+        await binder.SetValueAsync(SerializeEnvelope(McpConstants.PromptResultContentTypes.GetPromptResult, inner), CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Empty(result.Messages);
+        Assert.Null(result.Description);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithDescriptionOnlyEnvelope_DeserializesInner()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        var inner = new GetPromptResult { Description = "some description" };
+
+        await binder.SetValueAsync(SerializeEnvelope(McpConstants.PromptResultContentTypes.GetPromptResult, inner), CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Equal("some description", result.Description);
+        Assert.Empty(result.Messages);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithPromptMessagesEnvelope_WrapsInGetPromptResult()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        var messages = new List<PromptMessage>
+        {
+            new() { Role = Role.User, Content = new TextContentBlock { Text = "Hello" } }
+        };
+
+        await binder.SetValueAsync(SerializeEnvelope(McpConstants.PromptResultContentTypes.PromptMessages, messages), CancellationToken.None);
 
         var result = await executionContext.ResultTask;
         Assert.NotNull(result);
         Assert.Single(result.Messages);
         Assert.Equal(Role.User, result.Messages[0].Role);
-        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
-        Assert.Equal("not a json { string", content.Text);
+        Assert.Equal("Hello", Assert.IsType<TextContentBlock>(result.Messages[0].Content).Text);
     }
 
     [Fact]
-    public async Task SetValueAsync_WithJsonHavingDescriptionOnly_DeserializesAsPromptResult()
+    public async Task SetValueAsync_WithUnknownEnvelopeType_Throws()
     {
         var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
         var binder = new PromptReturnValueBinder(executionContext);
 
-        var json = """{"description": "some description"}""";
-        await binder.SetValueAsync(json, CancellationToken.None);
-
-        var result = await executionContext.ResultTask;
-        Assert.NotNull(result);
-        Assert.NotNull(result.Messages);
-        Assert.Empty(result.Messages);
-        Assert.Equal("some description", result.Description);
-    }
-
-    [Fact]
-    public async Task SetValueAsync_WithEmptyString_WrapsAsUserMessage()
-    {
-        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
-        var binder = new PromptReturnValueBinder(executionContext);
-
-        await binder.SetValueAsync("", CancellationToken.None);
-
-        var result = await executionContext.ResultTask;
-        Assert.NotNull(result);
-        Assert.Single(result.Messages);
-        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
-        Assert.Equal("", content.Text);
-    }
-
-    [Fact]
-    public async Task SetValueAsync_WithUnsupportedType_ThrowsInvalidOperationException()
-    {
-        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
-        var binder = new PromptReturnValueBinder(executionContext);
+        var envelope = new McpPromptResult
+        {
+            Type = "not_a_known_type",
+            Content = "{}"
+        };
+        var json = JsonSerializer.Serialize(envelope, McpJsonSerializerOptions.DefaultOptions);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => binder.SetValueAsync(42, CancellationToken.None));
+            () => binder.SetValueAsync(json, CancellationToken.None));
 
-        Assert.Contains("Unsupported return type", exception.Message);
-        Assert.Contains("Int32", exception.Message);
+        Assert.Contains("Unknown McpPromptResult type", exception.Message);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithMissingContent_Throws()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        var envelope = new McpPromptResult
+        {
+            Type = McpConstants.PromptResultContentTypes.GetPromptResult,
+            Content = null
+        };
+        var json = JsonSerializer.Serialize(envelope, McpJsonSerializerOptions.DefaultOptions);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => binder.SetValueAsync(json, CancellationToken.None));
+
+        Assert.Contains("Content was null", exception.Message);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithNonStringValue_ThrowsArgumentException()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => binder.SetValueAsync(42, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithInvalidJson_ThrowsInvalidOperationException()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new PromptReturnValueBinder(executionContext);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => binder.SetValueAsync("not a json { string", CancellationToken.None));
     }
 
     [Fact]
@@ -148,5 +175,15 @@ public class PromptReturnValueBinderTests
         var binder = new PromptReturnValueBinder(executionContext);
 
         Assert.Equal(string.Empty, binder.ToInvokeString());
+    }
+
+    private static string SerializeEnvelope<T>(string type, T inner)
+    {
+        var envelope = new McpPromptResult
+        {
+            Type = type,
+            Content = JsonSerializer.Serialize(inner, McpJsonUtilities.DefaultOptions)
+        };
+        return JsonSerializer.Serialize(envelope, McpJsonSerializerOptions.DefaultOptions);
     }
 }

--- a/test/Extensions.Mcp.Tests/SimplePromptReturnValueBinderTests.cs
+++ b/test/Extensions.Mcp.Tests/SimplePromptReturnValueBinderTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using ModelContextProtocol.Protocol;
+
+namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
+
+public class SimplePromptReturnValueBinderTests
+{
+    [Fact]
+    public async Task SetValueAsync_WithNull_SetsEmptyMessages()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        await binder.SetValueAsync(null!, CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Empty(result.Messages);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithPlainString_WrapsAsUserTextMessage()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        await binder.SetValueAsync("Please review this code", CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Single(result.Messages);
+        Assert.Equal(Role.User, result.Messages[0].Role);
+        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
+        Assert.Equal("Please review this code", content.Text);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithEmptyString_WrapsAsUserTextMessage()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        await binder.SetValueAsync(string.Empty, CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Single(result.Messages);
+        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
+        Assert.Equal(string.Empty, content.Text);
+    }
+
+    [Fact]
+    public async Task SetValueAsync_WithNonStringValue_UsesToString()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        await binder.SetValueAsync(42, CancellationToken.None);
+
+        var result = await executionContext.ResultTask;
+        Assert.NotNull(result);
+        Assert.Single(result.Messages);
+        var content = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
+        Assert.Equal("42", content.Text);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_ThrowsNotSupportedException()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => binder.GetValueAsync());
+    }
+
+    [Fact]
+    public void ToInvokeString_ReturnsEmptyString()
+    {
+        var executionContext = GetPromptExecutionContextHelper.CreateExecutionContext();
+        var binder = new SimplePromptReturnValueBinder(executionContext);
+
+        Assert.Equal(string.Empty, binder.ToInvokeString());
+    }
+}

--- a/test/TestAppIsolated/Prompts/PromptFunctions.cs
+++ b/test/TestAppIsolated/Prompts/PromptFunctions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
 
 namespace TestAppIsolated.Prompts;
 
@@ -15,10 +16,11 @@ public class PromptFunctions(ILogger<PromptFunctions> logger)
 {
     /// <summary>
     /// A prompt with multiple arguments (1 required, 1 optional).
-    /// Tests multi-argument prompt with mixed required/optional + Title + Description.
+    /// Returns a GetPromptResult with structured messages; the SDK middleware
+    /// serializes this to a GetPromptResult JSON for the host to consume.
     /// </summary>
     [Function(nameof(CodeReviewPrompt))]
-    public string CodeReviewPrompt(
+    public GetPromptResult CodeReviewPrompt(
         [McpPromptTrigger(
             "code_review",
             Title = "Code Review",
@@ -32,7 +34,21 @@ public class PromptFunctions(ILogger<PromptFunctions> logger)
         code ??= "// no code provided";
         language ??= "unknown";
 
-        return $"Please review the following {language} code and suggest improvements:\n\n```{language}\n{code}\n```";
+        return new GetPromptResult
+        {
+            Description = $"Code review prompt for {language}",
+            Messages =
+            [
+                new PromptMessage
+                {
+                    Role = Role.User,
+                    Content = new TextContentBlock
+                    {
+                        Text = $"Please review the following {language} code and suggest improvements:\n\n```{language}\n{code}\n```"
+                    }
+                }
+            ]
+        };
     }
 
     /// <summary>
@@ -125,5 +141,43 @@ public class PromptFunctions(ILogger<PromptFunctions> logger)
         logger.LogInformation("Generating fluent prompt");
         // Arguments are defined via builder in Program.cs, accessed through the context
         return "This prompt has its arguments defined via the fluent builder API.";
+    }
+
+    /// <summary>
+    /// A prompt that returns an IList&lt;PromptMessage&gt; directly (a multi-turn
+    /// conversation seed). The SDK middleware wraps the list in a GetPromptResult
+    /// before serializing it for the host.
+    /// </summary>
+    [Function(nameof(MultiTurnPrompt))]
+    public IList<PromptMessage> MultiTurnPrompt(
+        [McpPromptTrigger(
+            "multi_turn_prompt",
+            Title = "Multi-Turn Prompt",
+            Description = "Returns a multi-turn conversation as an IList<PromptMessage>")]
+        PromptInvocationContext context,
+        [McpPromptArgument("topic", "The topic to discuss", isRequired: true)] string? topic)
+    {
+        logger.LogInformation("Generating multi-turn prompt");
+
+        topic ??= "general";
+
+        return
+        [
+            new PromptMessage
+            {
+                Role = Role.User,
+                Content = new TextContentBlock { Text = $"Let's discuss {topic}." }
+            },
+            new PromptMessage
+            {
+                Role = Role.Assistant,
+                Content = new TextContentBlock { Text = $"Sure, what about {topic} would you like to explore?" }
+            },
+            new PromptMessage
+            {
+                Role = Role.User,
+                Content = new TextContentBlock { Text = "Start with the basics." }
+            }
+        ];
     }
 }

--- a/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
+++ b/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
@@ -256,9 +256,33 @@ public class FunctionsMcpPromptResultMiddlewareTests
     private GetPromptResult DeserializePromptResult()
     {
         var json = Assert.IsType<string>(_currentResult);
-        var promptResult = JsonSerializer.Deserialize<GetPromptResult>(json, McpJsonUtilities.DefaultOptions);
-        Assert.NotNull(promptResult);
-        return promptResult!;
+        var envelope = JsonSerializer.Deserialize<McpPromptResult>(json, McpJsonUtilities.DefaultOptions);
+        Assert.NotNull(envelope);
+        Assert.NotNull(envelope!.Content);
+
+        if (string.Equals(envelope.Type, Constants.GetPromptResultType, StringComparison.OrdinalIgnoreCase))
+        {
+            var promptResult = JsonSerializer.Deserialize<GetPromptResult>(envelope.Content!, McpJsonUtilities.DefaultOptions);
+            Assert.NotNull(promptResult);
+            return promptResult!;
+        }
+
+        if (string.Equals(envelope.Type, Constants.PromptMessagesType, StringComparison.OrdinalIgnoreCase))
+        {
+            var messages = JsonSerializer.Deserialize<IList<PromptMessage>>(envelope.Content!, McpJsonUtilities.DefaultOptions);
+            Assert.NotNull(messages);
+            return new GetPromptResult { Messages = messages! };
+        }
+
+        throw new InvalidOperationException($"Unexpected envelope type '{envelope.Type}'.");
+    }
+
+    private string GetEnvelopeType()
+    {
+        var json = Assert.IsType<string>(_currentResult);
+        var envelope = JsonSerializer.Deserialize<McpPromptResult>(json, McpJsonUtilities.DefaultOptions);
+        Assert.NotNull(envelope);
+        return envelope!.Type;
     }
 
     private static FunctionContext CreateMcpPromptFunctionContext()

--- a/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
+++ b/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
@@ -153,10 +153,35 @@ public class FunctionsMcpPromptResultMiddlewareTests
             return Task.CompletedTask;
         });
 
+        Assert.Equal(Constants.PromptMessagesType, GetEnvelopeType());
         var promptResult = DeserializePromptResult();
         Assert.Equal(2, promptResult.Messages.Count);
         Assert.Equal(Role.User, promptResult.Messages[0].Role);
         Assert.Equal(Role.Assistant, promptResult.Messages[1].Role);
+    }
+
+    [Fact]
+    public async Task Invoke_WithPromptMessageEnumerable_WrapsInGetPromptResult()
+    {
+        var context = CreateMcpPromptFunctionContext();
+
+        static IEnumerable<PromptMessage> Iterator()
+        {
+            yield return new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = "First" } };
+            yield return new PromptMessage { Role = Role.Assistant, Content = new TextContentBlock { Text = "Second" } };
+        }
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, Iterator());
+            return Task.CompletedTask;
+        });
+
+        Assert.Equal(Constants.PromptMessagesType, GetEnvelopeType());
+        var promptResult = DeserializePromptResult();
+        Assert.Equal(2, promptResult.Messages.Count);
+        Assert.Equal("First", Assert.IsType<TextContentBlock>(promptResult.Messages[0].Content).Text);
+        Assert.Equal("Second", Assert.IsType<TextContentBlock>(promptResult.Messages[1].Content).Text);
     }
 
     [Fact]

--- a/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
+++ b/test/Worker.Extensions.Mcp.Sdk.Tests/FunctionsMcpPromptResultMiddlewareTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using Moq;
+
+namespace Worker.Extensions.Mcp.Sdk.Tests;
+
+public class FunctionsMcpPromptResultMiddlewareTests
+{
+    private readonly Mock<IFunctionResultAccessor> _resultAccessorMock;
+    private readonly FunctionsMcpPromptResultMiddleware _middleware;
+    private object? _currentResult;
+
+    public FunctionsMcpPromptResultMiddlewareTests()
+    {
+        _resultAccessorMock = new Mock<IFunctionResultAccessor>();
+        _resultAccessorMock
+            .Setup(a => a.GetResult(It.IsAny<FunctionContext>()))
+            .Returns(() => _currentResult);
+        _resultAccessorMock
+            .Setup(a => a.SetResult(It.IsAny<FunctionContext>(), It.IsAny<object?>()))
+            .Callback<FunctionContext, object?>((ctx, value) => _currentResult = value);
+        _middleware = new FunctionsMcpPromptResultMiddleware(_resultAccessorMock.Object);
+    }
+
+    [Fact]
+    public async Task Invoke_WithNonMcpPromptContext_DoesNotModifyResult()
+    {
+        var context = CreateFunctionContextWithoutPromptInvocationContext();
+        var originalValue = "original value";
+        SetInvocationResult(context, originalValue);
+        var nextCalled = false;
+
+        Task Next(FunctionContext _)
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await _middleware.Invoke(context, Next);
+
+        Assert.True(nextCalled);
+        Assert.Equal(originalValue, _currentResult);
+    }
+
+    [Fact]
+    public async Task Invoke_WithNullResult_DoesNotModifyResult()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        SetInvocationResult(context, null);
+
+        await _middleware.Invoke(context, _ => Task.CompletedTask);
+
+        Assert.Null(_currentResult);
+    }
+
+    [Fact]
+    public async Task Invoke_WithStringResult_WrapsInGetPromptResultWithTextMessage()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var expectedText = "Please summarize the following text...";
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, expectedText);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Single(promptResult.Messages);
+
+        var message = promptResult.Messages[0];
+        Assert.Equal(Role.User, message.Role);
+        var textBlock = Assert.IsType<TextContentBlock>(message.Content);
+        Assert.Equal(expectedText, textBlock.Text);
+    }
+
+    [Fact]
+    public async Task Invoke_WithGetPromptResult_SerializesDirectly()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var getPromptResult = new GetPromptResult
+        {
+            Description = "Code review for Python",
+            Messages =
+            [
+                new PromptMessage
+                {
+                    Role = Role.User,
+                    Content = new TextContentBlock { Text = "Review this code..." }
+                }
+            ]
+        };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, getPromptResult);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Equal("Code review for Python", promptResult.Description);
+        Assert.Single(promptResult.Messages);
+
+        var textBlock = Assert.IsType<TextContentBlock>(promptResult.Messages[0].Content);
+        Assert.Equal("Review this code...", textBlock.Text);
+    }
+
+    [Fact]
+    public async Task Invoke_WithSinglePromptMessage_WrapsInGetPromptResult()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var promptMessage = new PromptMessage
+        {
+            Role = Role.Assistant,
+            Content = new TextContentBlock { Text = "I'll review your code now." }
+        };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, promptMessage);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Single(promptResult.Messages);
+        Assert.Equal(Role.Assistant, promptResult.Messages[0].Role);
+
+        var textBlock = Assert.IsType<TextContentBlock>(promptResult.Messages[0].Content);
+        Assert.Equal("I'll review your code now.", textBlock.Text);
+    }
+
+    [Fact]
+    public async Task Invoke_WithPromptMessageList_WrapsInGetPromptResult()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var messages = new List<PromptMessage>
+        {
+            new() { Role = Role.User, Content = new TextContentBlock { Text = "Review this code" } },
+            new() { Role = Role.Assistant, Content = new TextContentBlock { Text = "Here is my review..." } }
+        };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, messages);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Equal(2, promptResult.Messages.Count);
+        Assert.Equal(Role.User, promptResult.Messages[0].Role);
+        Assert.Equal(Role.Assistant, promptResult.Messages[1].Role);
+    }
+
+    [Fact]
+    public async Task Invoke_WithObjectResult_SerializesAsJsonTextInPromptResult()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var poco = new { name = "Alice", score = 95 };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, poco);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Single(promptResult.Messages);
+
+        var textBlock = Assert.IsType<TextContentBlock>(promptResult.Messages[0].Content);
+        Assert.Contains("Alice", textBlock.Text);
+        Assert.Contains("95", textBlock.Text);
+    }
+
+    [Fact]
+    public async Task Invoke_WithGetPromptResultWithMultipleMessages_PreservesAll()
+    {
+        var context = CreateMcpPromptFunctionContext();
+        var getPromptResult = new GetPromptResult
+        {
+            Messages =
+            [
+                new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = "What does this code do?" } },
+                new PromptMessage { Role = Role.Assistant, Content = new TextContentBlock { Text = "This code implements a sorting algorithm..." } },
+                new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = "Can you optimize it?" } }
+            ]
+        };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, getPromptResult);
+            return Task.CompletedTask;
+        });
+
+        var promptResult = DeserializePromptResult();
+        Assert.Equal(3, promptResult.Messages.Count);
+    }
+
+    [Fact]
+    public async Task Invoke_WithOutputBindings_DoesNotModifyResult()
+    {
+        var outputBindings = new Dictionary<string, BindingMetadata>
+        {
+            { "$return", CreateOutputBindingMetadata() }
+        }.ToImmutableDictionary();
+
+        var context = CreateMcpPromptFunctionContextWithOutputBindings(outputBindings);
+
+        var getPromptResult = new GetPromptResult
+        {
+            Messages =
+            [
+                new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = "test" } }
+            ]
+        };
+
+        await _middleware.Invoke(context, ctx =>
+        {
+            SetInvocationResult(ctx, getPromptResult);
+            return Task.CompletedTask;
+        });
+
+        Assert.IsType<GetPromptResult>(_currentResult);
+    }
+
+    [Fact]
+    public async Task Invoke_WithToolContext_DoesNotProcessAsPrompt()
+    {
+        var items = new Dictionary<object, object>
+        {
+            { Constants.ToolInvocationContextKey, new ToolInvocationContext { Name = "TestTool" } }
+        };
+
+        var functionDefinitionMock = new Mock<FunctionDefinition>();
+        functionDefinitionMock.SetupGet(d => d.OutputBindings).Returns(ImmutableDictionary<string, BindingMetadata>.Empty);
+
+        var contextMock = new Mock<FunctionContext>();
+        contextMock.SetupGet(c => c.Items).Returns(items);
+        contextMock.SetupGet(c => c.FunctionDefinition).Returns(functionDefinitionMock.Object);
+
+        var originalValue = "original";
+        SetInvocationResult(contextMock.Object, originalValue);
+
+        await _middleware.Invoke(contextMock.Object, _ => Task.CompletedTask);
+
+        Assert.Equal(originalValue, _currentResult);
+    }
+
+    private GetPromptResult DeserializePromptResult()
+    {
+        var json = Assert.IsType<string>(_currentResult);
+        var promptResult = JsonSerializer.Deserialize<GetPromptResult>(json, McpJsonUtilities.DefaultOptions);
+        Assert.NotNull(promptResult);
+        return promptResult!;
+    }
+
+    private static FunctionContext CreateMcpPromptFunctionContext()
+    {
+        var items = new Dictionary<object, object>
+        {
+            { Constants.PromptInvocationContextKey, new PromptInvocationContext { Name = "TestPrompt" } }
+        };
+
+        var functionDefinitionMock = new Mock<FunctionDefinition>();
+        functionDefinitionMock.SetupGet(d => d.OutputBindings).Returns(ImmutableDictionary<string, BindingMetadata>.Empty);
+
+        var contextMock = new Mock<FunctionContext>();
+        contextMock.SetupGet(c => c.Items).Returns(items);
+        contextMock.SetupGet(c => c.FunctionDefinition).Returns(functionDefinitionMock.Object);
+
+        return contextMock.Object;
+    }
+
+    private static FunctionContext CreateFunctionContextWithoutPromptInvocationContext()
+    {
+        var items = new Dictionary<object, object>();
+
+        var functionDefinitionMock = new Mock<FunctionDefinition>();
+        functionDefinitionMock.SetupGet(d => d.OutputBindings).Returns(ImmutableDictionary<string, BindingMetadata>.Empty);
+
+        var contextMock = new Mock<FunctionContext>();
+        contextMock.SetupGet(c => c.Items).Returns(items);
+        contextMock.SetupGet(c => c.FunctionDefinition).Returns(functionDefinitionMock.Object);
+
+        return contextMock.Object;
+    }
+
+    private static FunctionContext CreateMcpPromptFunctionContextWithOutputBindings(
+        IImmutableDictionary<string, BindingMetadata> outputBindings)
+    {
+        var items = new Dictionary<object, object>
+        {
+            { Constants.PromptInvocationContextKey, new PromptInvocationContext { Name = "TestPrompt" } }
+        };
+
+        var functionDefinitionMock = new Mock<FunctionDefinition>();
+        functionDefinitionMock.SetupGet(d => d.OutputBindings).Returns(outputBindings);
+
+        var contextMock = new Mock<FunctionContext>();
+        contextMock.SetupGet(c => c.Items).Returns(items);
+        contextMock.SetupGet(c => c.FunctionDefinition).Returns(functionDefinitionMock.Object);
+
+        return contextMock.Object;
+    }
+
+    private static BindingMetadata CreateOutputBindingMetadata()
+    {
+        var mock = new Mock<BindingMetadata>();
+        mock.SetupGet(b => b.Direction).Returns(BindingDirection.Out);
+        mock.SetupGet(b => b.Type).Returns("http");
+        return mock.Object;
+    }
+
+    private void SetInvocationResult(FunctionContext context, object? value)
+    {
+        _currentResult = value;
+    }
+}

--- a/test/Worker.Extensions.Mcp.Sdk.Tests/McpUseResultSchemaTransformerTests.cs
+++ b/test/Worker.Extensions.Mcp.Sdk.Tests/McpUseResultSchemaTransformerTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+using Moq;
+
+namespace Worker.Extensions.Mcp.Sdk.Tests;
+
+public class McpUseResultSchemaTransformerTests
+{
+    private readonly McpUseResultSchemaTransformer _transformer = new();
+
+    [Fact]
+    public void Transform_McpToolTrigger_NoOutputBindings_SetsUseResultSchemaTrue()
+    {
+        var function = CreateFunction(
+            """{"type":"mcpToolTrigger","direction":"in","name":"trigger"}""");
+
+        _transformer.Transform([function]);
+
+        Assert.True(GetFlag(function.RawBindings![0]));
+    }
+
+    [Fact]
+    public void Transform_McpPromptTrigger_DoesNotSetFlag()
+    {
+        // Prompts do not use the envelope contract; the host always deserializes
+        // a GetPromptResult directly. The transformer should leave prompt bindings alone.
+        var function = CreateFunction(
+            """{"type":"mcpPromptTrigger","direction":"in","name":"trigger"}""");
+
+        _transformer.Transform([function]);
+
+        Assert.Null(GetFlag(function.RawBindings![0]));
+    }
+
+    [Fact]
+    public void Transform_McpToolTrigger_WithOutputBinding_DoesNotSetFlag()
+    {
+        var function = CreateFunction(
+            """{"type":"mcpToolTrigger","direction":"in","name":"trigger"}""",
+            """{"type":"queue","direction":"out","name":"outQueue"}""");
+
+        _transformer.Transform([function]);
+
+        Assert.Null(GetFlag(function.RawBindings![0]));
+    }
+
+    [Fact]
+    public void Transform_NonMcpBinding_IsIgnored()
+    {
+        var function = CreateFunction(
+            """{"type":"httpTrigger","direction":"in","name":"req"}""");
+
+        _transformer.Transform([function]);
+
+        Assert.Null(GetFlag(function.RawBindings![0]));
+    }
+
+    [Fact]
+    public void Transform_NullOrEmpty_DoesNotThrow()
+    {
+        _transformer.Transform([]);
+
+        var nullBindings = new Mock<IFunctionMetadata>();
+        nullBindings.SetupGet(x => x.RawBindings).Returns((IList<string>)null!);
+        _transformer.Transform([nullBindings.Object]);
+    }
+
+    private static bool? GetFlag(string bindingJson)
+    {
+        var node = JsonNode.Parse(bindingJson) as JsonObject;
+        return node?["useResultSchema"]?.GetValue<bool>();
+    }
+
+    private static IFunctionMetadata CreateFunction(params string[] rawBindings)
+    {
+        var mock = new Mock<IFunctionMetadata>();
+        mock.SetupGet(x => x.RawBindings).Returns(rawBindings.ToList());
+        return mock.Object;
+    }
+}

--- a/test/Worker.Extensions.Mcp.Sdk.Tests/McpUseResultSchemaTransformerTests.cs
+++ b/test/Worker.Extensions.Mcp.Sdk.Tests/McpUseResultSchemaTransformerTests.cs
@@ -24,12 +24,22 @@ public class McpUseResultSchemaTransformerTests
     }
 
     [Fact]
-    public void Transform_McpPromptTrigger_DoesNotSetFlag()
+    public void Transform_McpPromptTrigger_NoOutputBindings_SetsUseResultSchemaTrue()
     {
-        // Prompts do not use the envelope contract; the host always deserializes
-        // a GetPromptResult directly. The transformer should leave prompt bindings alone.
         var function = CreateFunction(
             """{"type":"mcpPromptTrigger","direction":"in","name":"trigger"}""");
+
+        _transformer.Transform([function]);
+
+        Assert.True(GetFlag(function.RawBindings![0]));
+    }
+
+    [Fact]
+    public void Transform_McpPromptTrigger_WithOutputBinding_DoesNotSetFlag()
+    {
+        var function = CreateFunction(
+            """{"type":"mcpPromptTrigger","direction":"in","name":"trigger"}""",
+            """{"type":"queue","direction":"out","name":"outQueue"}""");
 
         _transformer.Transform([function]);
 

--- a/test/Worker.Mcp.E2ETests/PromptTests/GetPromptTests.cs
+++ b/test/Worker.Mcp.E2ETests/PromptTests/GetPromptTests.cs
@@ -30,6 +30,7 @@ public class GetPromptTests(DefaultProjectFixture fixture, ITestOutputHelper tes
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
+        Assert.Equal("Code review prompt for python", result.Description);
         Assert.Single(result.Messages);
 
         var message = result.Messages[0];
@@ -189,6 +190,38 @@ public class GetPromptTests(DefaultProjectFixture fixture, ITestOutputHelper tes
         var message = result.Messages[0];
         var textContent = Assert.IsType<TextContentBlock>(message.Content);
         Assert.Contains("fluent builder API", textContent.Text);
+    }
+
+    [Theory]
+    [InlineData(HttpTransportMode.Sse)]
+    [InlineData(HttpTransportMode.AutoDetect)]
+    [InlineData(HttpTransportMode.StreamableHttp)]
+    public async Task GetPrompt_MultiTurn_ReturnsPromptMessageList(HttpTransportMode mode)
+    {
+        var client = await Fixture.CreateClientAsync(mode);
+
+        var result = await client.GetPromptAsync(
+            "multi_turn_prompt",
+            new Dictionary<string, object?>
+            {
+                ["topic"] = "compilers"
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Messages.Count);
+
+        Assert.Equal(Role.User, result.Messages[0].Role);
+        var firstUser = Assert.IsType<TextContentBlock>(result.Messages[0].Content);
+        Assert.Contains("compilers", firstUser.Text);
+
+        Assert.Equal(Role.Assistant, result.Messages[1].Role);
+        var assistant = Assert.IsType<TextContentBlock>(result.Messages[1].Content);
+        Assert.Contains("compilers", assistant.Text);
+
+        Assert.Equal(Role.User, result.Messages[2].Role);
+        var secondUser = Assert.IsType<TextContentBlock>(result.Messages[2].Content);
+        Assert.Contains("basics", secondUser.Text);
     }
 
     [Theory]


### PR DESCRIPTION
> ⚠️ **MCP version skew — non-text prompt content does not round-trip**
 >
 > The host extension still depends on `ModelContextProtocol` **0.4.0-preview.3**, while this SDK pulls in 
**1.2.0**. The two versions encode `byte`-backed content blocks (`ImageContentBlock.Data`, `AudioContentBlock.Data`, `BlobResourceContents.Blob`) differently on the wire — 1.2.0 produces a base64 string, 0.4.0 a JSON byte array.
 >
 > A worker function that returns `GetPromptResult` / `IList<PromptMessage>` containing **non-text** content blocks 
will serialize fine via the SDK middleware, decode fine in the host, but the host then re-serializes those blocks to
 the MCP client with its older types, producing JSON the client rejects (`"Invalid Base64 string"`).
 >
 > **For this PR, only text content is supported end-to-end.** Image / audio / embedded-resource content in prompt 
results requires aligning the host on `ModelContextProtocol` 1.2.0 — tracked separately.

### Issue describing the changes in this PR

Resolves #235

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)


### Additional information

Adds `FunctionsMcpPromptResultMiddleware` to the `Worker.Extensions.Mcp.Sdk` package, enabling prompt functions to return rich types (`GetPromptResult`, `PromptMessage`, `IList<PromptMessage>`) instead of only plain strings.

The middleware follows the same pattern as `FunctionsMcpToolResultMiddleware`:
- Intercepts prompt function results in the worker pipeline
- Serializes them into `McpPromptResult` wrapper format
- Host-side `PromptReturnValueBinder` deserializes and processes the wrapper

#### Supported return types

| Return Type | Behavior |
|-------------|----------|
| `GetPromptResult` | Serialized directly with description and messages |
| `PromptMessage` | Wrapped in a single-element message list |
| `IList<PromptMessage>` | Serialized as message array |
| `string` / `object` | Wrapped as text in a `Role.User` `PromptMessage` (default, backwards compatible) |
