### PR TITLE
Extensibility Changes for Tool Property Resolution

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/AttributeBasedToolPropertiesResolver.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/AttributeBasedToolPropertiesResolver.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Resolves tool properties by reflecting over the function's method signature
+/// and extracting properties from attributes.
+/// </summary>
+internal class AttributeBasedToolPropertiesResolver : IToolPropertiesResolver
+{
+    public bool TryResolve(string toolName, IFunctionMetadata functionMetadata, out List<ToolProperty>? toolProperties)
+    {
+        return ToolPropertyParser.TryGetPropertiesFromAttributes(functionMetadata, out toolProperties);
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ConfiguredToolPropertiesResolver.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ConfiguredToolPropertiesResolver.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Resolves tool properties from explicitly configured options
+/// set via <c>WithProperty(...)</c>.
+/// </summary>
+internal class ConfiguredToolPropertiesResolver(IOptionsMonitor<ToolOptions> toolOptionsMonitor) : IToolPropertiesResolver
+{
+    public bool TryResolve(string toolName, IFunctionMetadata functionMetadata, out List<ToolProperty>? toolProperties)
+    {
+        toolProperties = null;
+
+        var toolOptions = toolOptionsMonitor.Get(toolName);
+
+        if (toolOptions.Properties.Count == 0)
+        {
+            return false;
+        }
+
+        toolProperties = toolOptions.Properties;
+        return true;
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/IToolPropertiesResolver.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/IToolPropertiesResolver.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Defines a strategy for resolving tool properties for an MCP tool trigger function.
+/// </summary>
+internal interface IToolPropertiesResolver
+{
+    /// <summary>
+    /// Attempts to resolve tool properties for the given tool name and function metadata.
+    /// </summary>
+    /// <param name="toolName">The name of the tool, used to look up tool options.</param>
+    /// <param name="functionMetadata">The function metadata for reflection-based resolution.</param>
+    /// <param name="toolProperties">The resolved tool properties, if successful.</param>
+    /// <returns>True if tool properties were resolved, false otherwise.</returns>
+    bool TryResolve(string toolName, IFunctionMetadata functionMetadata, out List<ToolProperty>? toolProperties);
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
@@ -14,6 +13,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 internal sealed class McpFunctionMetadataTransformer(
     IOptionsMonitor<ToolOptions> toolOptionsMonitor,
     IOptionsMonitor<ResourceOptions> resourceOptionsMonitor,
+    IEnumerable<IToolPropertiesResolver> toolPropertiesResolvers,
     ILogger<McpFunctionMetadataTransformer> logger)
     : IFunctionMetadataTransformer
 {
@@ -53,7 +53,7 @@ internal sealed class McpFunctionMetadataTransformer(
                         {
                             toolName = toolNameNode?.ToString();
 
-                            if (GetToolProperties(toolName, function, out toolProperties))
+                            if (TryResolveToolProperties(toolName, function, out toolProperties))
                             {
                                 jsonObject["toolProperties"] = ToolPropertyParser.GetPropertiesJson(toolProperties);
                             }
@@ -121,7 +121,7 @@ internal sealed class McpFunctionMetadataTransformer(
         }
     }
 
-    private bool GetToolProperties(string? toolName, IFunctionMetadata functionMetadata, [NotNullWhen(true)] out List<ToolProperty>? toolProperties)
+    private bool TryResolveToolProperties(string? toolName, IFunctionMetadata functionMetadata, out List<ToolProperty>? toolProperties)
     {
         toolProperties = null;
 
@@ -130,16 +130,16 @@ internal sealed class McpFunctionMetadataTransformer(
             return false;
         }
 
-        // Get from configured options first:
-        var toolOptions = toolOptionsMonitor.Get(toolName);
-
-        if (toolOptions.Properties.Count != 0)
+        foreach (var resolver in toolPropertiesResolvers)
         {
-            toolProperties = toolOptions.Properties;
-            return true;
+            if (resolver.TryResolve(toolName, functionMetadata, out toolProperties) && toolProperties is not null)
+            {
+                return true;
+            }
         }
 
-        return ToolPropertyParser.TryGetPropertiesFromAttributes(functionMetadata, out toolProperties);
+        toolProperties = null;
+        return false;
     }
 
     private static void TryApplyMetadata<TOptions>(string? name, JsonObject jsonObject, IOptionsMonitor<TOptions> optionsMonitor)
@@ -208,6 +208,4 @@ internal sealed class McpFunctionMetadataTransformer(
 
         return fluentNode.ToJsonString();
     }
-
-    private record ToolPropertyBinding(int Index, JsonObject Binding);
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolPropertyBinding.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolPropertyBinding.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Represents a tool property binding that can be patched with type information.
+/// </summary>
+/// <param name="Index">The index of this binding in the raw bindings list.</param>
+/// <param name="Binding">The JSON object representing the binding configuration.</param>
+internal record ToolPropertyBinding(int Index, JsonObject Binding);

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/HostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/HostBuilderExtensions.cs
@@ -41,6 +41,11 @@ public static class McpHostBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // Tool properties resolvers are registered in priority order.
+        // The transformer iterates them and returns the first successful resolution.
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolPropertiesResolver, ConfiguredToolPropertiesResolver>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolPropertiesResolver, AttributeBasedToolPropertiesResolver>());
+
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IFunctionMetadataTransformer, McpFunctionMetadataTransformer>());
 
         builder.UseMiddleware<FunctionsMcpContextMiddleware>();

--- a/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataTransformerTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataTransformerTests.cs
@@ -60,7 +60,7 @@ public class McpFunctionMetadataTransformerTests
             options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
             var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
             resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
             var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"NoAttributes\"}"]);
 
@@ -86,7 +86,7 @@ public class McpFunctionMetadataTransformerTests
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
 
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint: null,
@@ -111,7 +111,7 @@ public class McpFunctionMetadataTransformerTests
             options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
             var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
             resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
             var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"WithToolProperty\"}"]);
 
@@ -132,7 +132,7 @@ public class McpFunctionMetadataTransformerTests
             options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
             var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
             resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
             var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"WithTriggerPoco\"}"]);
 
@@ -150,7 +150,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata("BadEntryPoint", "Some.dll", "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"Bad\"}"]);
         fn.SetupGet(f => f.RawBindings).Returns(["{\"type\":\"mcpToolTrigger\",\"toolName\":\"Bad\"}"]);
@@ -172,7 +172,7 @@ public class McpFunctionMetadataTransformerTests
             options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
             var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
             resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
             var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"Whatever\"}"]);
             transformer.Transform([fn.Object]);
@@ -193,7 +193,7 @@ public class McpFunctionMetadataTransformerTests
             options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
             var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
             resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+            var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
             var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"WithToolProperty\"}"]);
             transformer.Transform([fn.Object]);
@@ -212,7 +212,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(entryPoint, scriptFile, "Func", ["{\"type\":\"mcpToolTrigger\",\"toolName\":\"WithContextAndPoco\"}"]);
         transformer.Transform([fn.Object]);
@@ -233,7 +233,7 @@ public class McpFunctionMetadataTransformerTests
         var options = new Mock<IOptionsMonitor<ToolOptions>>();
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -259,7 +259,7 @@ public class McpFunctionMetadataTransformerTests
         var options = new Mock<IOptionsMonitor<ToolOptions>>();
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -284,7 +284,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -311,7 +311,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -340,7 +340,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get("NoAttributes")).Returns(toolOptions);
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -372,7 +372,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get("file://test")).Returns(resourceOpts);
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -402,7 +402,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get("WithToolMetadata")).Returns(toolOptions);
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -436,7 +436,7 @@ public class McpFunctionMetadataTransformerTests
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get("file://test")).Returns(resourceOpts);
-        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        var transformer = new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, CreateToolPropertiesResolvers(options.Object), NullLogger<McpFunctionMetadataTransformer>.Instance);
 
         var fn = CreateFunctionMetadata(
             entryPoint,
@@ -526,6 +526,15 @@ public class McpFunctionMetadataTransformerTests
         Assert.Contains("b", overlapping);
     }
 
+    private static IToolPropertiesResolver[] CreateToolPropertiesResolvers(IOptionsMonitor<ToolOptions> toolOptionsMonitor)
+    {
+        return
+        [
+            new ConfiguredToolPropertiesResolver(toolOptionsMonitor),
+            new AttributeBasedToolPropertiesResolver(),
+        ];
+    }
+
     private static McpFunctionMetadataTransformer CreateTransformer(List<ToolProperty>? configured = null)
     {
         var options =  new Mock<IOptionsMonitor<ToolOptions>>();
@@ -533,7 +542,11 @@ public class McpFunctionMetadataTransformerTests
             .Returns(new ToolOptions { Properties = configured ?? [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
         resourceOptions.Setup(o => o.Get(It.IsAny<string>())).Returns(new ResourceOptions());
-        return new McpFunctionMetadataTransformer(options.Object, resourceOptions.Object, NullLogger<McpFunctionMetadataTransformer>.Instance);
+        return new McpFunctionMetadataTransformer(
+            options.Object,
+            resourceOptions.Object,
+            CreateToolPropertiesResolvers(options.Object),
+            NullLogger<McpFunctionMetadataTransformer>.Instance);
     }
 
     private static Mock<IFunctionMetadata> CreateFunctionMetadata(string? entryPoint, string? scriptFile, string? name, IList<string>? bindings)


### PR DESCRIPTION
Extract tool property resolution from McpFunctionMetadataTransformer into a pluggable resolver pattern:

- Add IToolPropertiesResolver interface
- Add ConfiguredToolPropertiesResolver (from ToolOptions.Properties)
- Add AttributeBasedToolPropertiesResolver (from function attributes)
- Extract ToolPropertyBinding record to its own file
- Register resolvers in DI with priority ordering
- Transformer now iterates resolvers instead of inline logic

No behavioral changes - same toolProperties output on bindings.

Will be used to build input schema creation in follow up PR

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
