### PR TITLE
 Fix builder context cleanup, harden JSON parsing, and fix test env var leaks

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBuilderContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBuilderContext.cs
@@ -47,5 +47,5 @@ internal sealed class McpBuilderContext
     /// Tracks tool names for which synthetic app functions have already been emitted,
     /// preventing duplicate generation.
     /// </summary>
-    public HashSet<string> EmittedAppTools { get; } = [];
+    public HashSet<string> EmittedAppTools { get; }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
@@ -57,7 +57,10 @@ internal static class AddAppUiMetadataExtension
         if (binding.JsonObject.TryGetPropertyValue("metadata", out var existingMetaNode)
             && existingMetaNode is not null)
         {
-            var metaStr = existingMetaNode.GetValue<string>();
+            var metaStr = existingMetaNode is JsonValue jsonValue
+                ? jsonValue.GetValue<string>()
+                : existingMetaNode.ToJsonString();
+
             metaObj = JsonNode.Parse(metaStr) as JsonObject ?? new JsonObject();
 
             if (metaObj.ContainsKey("ui"))

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/MetadataMerger.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/MetadataMerger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
@@ -18,12 +19,8 @@ internal static class MetadataMerger
     /// </summary>
     internal static string MergeMetadata(string? fluentJson, string? attributedJson, out List<string> overlappingKeys)
     {
-        var fluentNode = string.IsNullOrWhiteSpace(fluentJson)
-            ? []
-            : JsonNode.Parse(fluentJson)?.AsObject() ?? throw new InvalidOperationException($"Failed to parse fluent API metadata as JSON object: {fluentJson}");
-        var attributedNode = string.IsNullOrWhiteSpace(attributedJson)
-            ? []
-            : JsonNode.Parse(attributedJson)?.AsObject() ?? throw new InvalidOperationException($"Failed to parse attributed metadata as JSON object: {attributedJson}");
+        var fluentNode = ParseAsJsonObject(fluentJson, "fluent API metadata");
+        var attributedNode = ParseAsJsonObject(attributedJson, "attributed metadata");
 
         overlappingKeys = [];
 
@@ -38,5 +35,26 @@ internal static class MetadataMerger
         }
 
         return fluentNode.ToJsonString();
+    }
+
+    private static JsonObject ParseAsJsonObject(string? json, string context)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return [];
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Failed to parse {context} as JSON: {json}", ex);
+        }
+
+        return node as JsonObject
+            ?? throw new InvalidOperationException($"Expected {context} to be a JSON object, but got: {json}");
     }
 }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
@@ -7,8 +7,15 @@ using static Worker.Extensions.Mcp.Tests.Helpers.BuilderTestHelper;
 
 namespace Worker.Extensions.Mcp.Tests.Configuration;
 
-public class AddMetadataExtensionTests
+public class AddMetadataExtensionTests : IDisposable
 {
+    private const string FunctionsApplicationDirectoryKey = "FUNCTIONS_APPLICATION_DIRECTORY";
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, null);
+    }
+
     [Fact]
     public void AddMetadata_FluentMetadataAppliedToToolTrigger()
     {

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
@@ -1,12 +1,18 @@
-using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 using static Worker.Extensions.Mcp.Tests.Helpers.BuilderTestHelper;
 
 namespace Worker.Extensions.Mcp.Tests.Configuration;
 
-public class AddToolPropertiesExtensionTests
+public class AddToolPropertiesExtensionTests : IDisposable
 {
+    private const string FunctionsApplicationDirectoryKey = "FUNCTIONS_APPLICATION_DIRECTORY";
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, null);
+    }
+
     [Fact]
     public void AddToolProperties_WithConfiguredOptions_SetsToolProperties()
     {

--- a/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataTransformerTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpFunctionMetadataTransformerTests.cs
@@ -13,9 +13,14 @@ using Moq;
 
 namespace Worker.Extensions.Mcp.Tests;
 
-public class McpFunctionMetadataTransformerTests
+public class McpFunctionMetadataTransformerTests : IDisposable
 {
     private const string FunctionsApplicationDirectoryKey = "FUNCTIONS_APPLICATION_DIRECTORY";
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, null);
+    }
 
     [Fact]
     public void Transform_NoRawBindings_DoesNothing()
@@ -158,6 +163,8 @@ public class McpFunctionMetadataTransformerTests
     [Fact]
     public void Transform_InvalidEntryPoint_NoChange()
     {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, Path.GetDirectoryName(typeof(McpFunctionMetadataTransformerTests).Assembly.Location));
+
         var options = new Mock<IOptionsMonitor<ToolOptions>>();
         options.Setup(o => o.Get(It.IsAny<string>())).Returns(new ToolOptions { Properties = [] });
         var resourceOptions = new Mock<IOptionsMonitor<ResourceOptions>>();
@@ -649,6 +656,8 @@ public class McpFunctionMetadataTransformerTests
     [Fact]
     public void Transform_ToolWithAppOptions_EmitsSyntheticResourceFunction()
     {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, Path.GetDirectoryName(typeof(McpFunctionMetadataTransformerTests).Assembly.Location));
+
         var appOptions = new AppOptions();
         appOptions.View = new ViewOptions
         {
@@ -689,6 +698,8 @@ public class McpFunctionMetadataTransformerTests
     [Fact]
     public void Transform_ToolWithStaticAssets_EmitsSingleResourceFunction()
     {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, Path.GetDirectoryName(typeof(McpFunctionMetadataTransformerTests).Assembly.Location));
+
         var appOptions = new AppOptions();
         appOptions.View = new ViewOptions
         {
@@ -750,6 +761,8 @@ public class McpFunctionMetadataTransformerTests
     [Fact]
     public void Transform_DuplicateToolNames_EmitsSingleSyntheticFunction()
     {
+        Environment.SetEnvironmentVariable(FunctionsApplicationDirectoryKey, Path.GetDirectoryName(typeof(McpFunctionMetadataTransformerTests).Assembly.Location));
+
         var appOptions = new AppOptions();
         appOptions.View = new ViewOptions
         {


### PR DESCRIPTION
 Small fixes to the MCP binding builder pipeline from code review of #216.
 
 ### Changes
 
 **Source fixes:**
 - `McpBuilderContext`: Remove wasted `EmittedAppTools` property initializer (constructor always overwrites it)
 - `MetadataMerger`: Extract `ParseAsJsonObject` helper that properly wraps `JsonException` and handles non-object 
JSON with clear error messages
 - `AddAppUiMetadataExtension`: Handle metadata node as either `JsonValue` (string) or other node types, instead of 
assuming `GetValue<string>()` always works
 
 **Test fixes:**
 - Add `IDisposable` to `McpFunctionMetadataTransformerTests`, `AddToolPropertiesExtensionTests`, and 
`AddMetadataExtensionTests` to clean up `FUNCTIONS_APPLICATION_DIRECTORY` env var after each test
 - Add explicit env var setup to 4 tests that were silently depending on leaked state from prior tests
 
 ### Pull request checklist
 
 * [x] My changes **do not** require documentation changes
 * [x] My changes **should not** be added to the release notes for the next release
 * [x] I have added all required tests (Unit tests, E2E tests)