### PR TITLE
Defer all JSON serialization to Build() in McpBindingBuilder

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 
@@ -44,7 +45,7 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
                 }
 
                 // Check binding type
-                if (jsonObject.TryGetPropertyValue("type", out var typeNode))
+                if (jsonObject.TryGetPropertyValue(BindingType, out var typeNode))
                 {
                     var bindingType = typeNode?.ToString();
                     if (string.Equals(bindingType, McpToolTriggerBindingType, StringComparison.OrdinalIgnoreCase))
@@ -78,10 +79,10 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
             }
 
             // Check if direction is "out"
-            if (jsonObject.TryGetPropertyValue("direction", out var directionNode))
+            if (jsonObject.TryGetPropertyValue(BindingDirectionProperty, out var directionNode))
             {
                 var direction = directionNode?.ToString();
-                if (string.Equals(direction, "out", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(direction, BindingDirectionOut, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
@@ -12,4 +12,9 @@ internal static class Constants
     public const string TextContextResult = "text";
 
     public const string CallToolResultType = "call_tool_result";
+
+    // Binding JSON property keys
+    public const string BindingType = "type";
+    public const string BindingDirectionProperty = "direction";
+    public const string BindingDirectionOut = "out";
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -39,17 +39,17 @@ internal sealed class McpBindingBuilder
         {
             if (binding.ToolProperties is not null)
             {
-                binding.JsonObject["toolProperties"] = binding.ToolProperties;
+                binding.JsonObject[McpToolProperties] = binding.ToolProperties;
             }
 
             if (binding.PromptArguments is not null)
             {
-                binding.JsonObject["promptArguments"] = binding.PromptArguments;
+                binding.JsonObject[McpPromptArguments] = binding.PromptArguments;
             }
 
             if (binding.Metadata is not null)
             {
-                binding.JsonObject["metadata"] = binding.Metadata.ToJsonString();
+                binding.JsonObject[McpMetadata] = binding.Metadata.ToJsonString();
             }
 
             if (binding.PropertyType is not null)
@@ -70,7 +70,7 @@ internal sealed class McpBindingBuilder
             var node = JsonNode.Parse(function.RawBindings[i]);
 
             if (node is not JsonObject jsonObject
-                || !jsonObject.TryGetPropertyValue("type", out var bindingTypeNode))
+                || !jsonObject.TryGetPropertyValue(BindingType, out var bindingTypeNode))
             {
                 continue;
             }
@@ -79,9 +79,9 @@ internal sealed class McpBindingBuilder
 
             string? identifier = bindingType switch
             {
-                McpToolTriggerBindingType => jsonObject["toolName"]?.ToString(),
-                McpResourceTriggerBindingType => jsonObject["uri"]?.ToString(),
-                McpPromptTriggerBindingType => jsonObject["promptName"]?.ToString(),
+                McpToolTriggerBindingType => jsonObject[McpToolName]?.ToString(),
+                McpResourceTriggerBindingType => jsonObject[McpUri]?.ToString(),
+                McpPromptTriggerBindingType => jsonObject[McpPromptName]?.ToString(),
                 McpToolPropertyBindingType => jsonObject[McpToolPropertyName]?.ToString(),
                 McpPromptArgumentBindingType => jsonObject[McpPromptArgumentName]?.ToString(),
                 _ => null,

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders;
@@ -15,10 +16,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal sealed class McpBindingBuilder
 {
-    public McpBindingBuilder(IFunctionMetadata function, ILogger logger, HashSet<string>? sharedEmittedAppTools = null)
+    public McpBindingBuilder(
+        IFunctionMetadata function,
+        ILogger logger,
+        IOptionsMonitor<ToolOptions> toolOptions,
+        IOptionsMonitor<ResourceOptions> resourceOptions,
+        IOptionsMonitor<PromptOptions> promptOptions,
+        HashSet<string>? sharedEmittedAppTools = null)
     {
         var bindings = ParseBindings(function);
-        Context = new McpBuilderContext(function, bindings, logger, sharedEmittedAppTools);
+        Context = new McpBuilderContext(function, bindings, logger, toolOptions, resourceOptions, promptOptions, sharedEmittedAppTools);
     }
 
     internal McpBuilderContext Context { get; }
@@ -99,10 +106,17 @@ internal sealed class McpBindingBuilder
     /// </summary>
     private static JsonObject? TryParseExistingMetadata(JsonObject jsonObject)
     {
-        if (jsonObject.TryGetPropertyValue("metadata", out var metaNode) && metaNode is not null)
+        try
         {
-            var metaStr = metaNode.GetValue<string>();
-            return JsonNode.Parse(metaStr)?.AsObject();
+            if (jsonObject.TryGetPropertyValue("metadata", out var metaNode) && metaNode is not null)
+            {
+                var metaStr = metaNode.GetValue<string>();
+                return JsonNode.Parse(metaStr)?.AsObject();
+            }
+        }
+        catch
+        {
+            // Malformed metadata is silently ignored; the binding proceeds without it.
         }
 
         return null;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -29,6 +29,26 @@ internal sealed class McpBindingBuilder
     {
         foreach (var binding in Context.Bindings)
         {
+            if (binding.ToolProperties is not null)
+            {
+                binding.JsonObject["toolProperties"] = binding.ToolProperties;
+            }
+
+            if (binding.PromptArguments is not null)
+            {
+                binding.JsonObject["promptArguments"] = binding.PromptArguments;
+            }
+
+            if (binding.Metadata is not null)
+            {
+                binding.JsonObject["metadata"] = binding.Metadata.ToJsonString();
+            }
+
+            if (binding.PropertyType is not null)
+            {
+                binding.JsonObject[McpToolPropertyType] = binding.PropertyType;
+            }
+
             Context.Function.RawBindings![binding.Index] = binding.JsonObject.ToJsonString();
         }
     }
@@ -64,9 +84,27 @@ internal sealed class McpBindingBuilder
                 continue;
             }
 
-            bindings.Add(new McpParsedBinding(i, bindingType!, identifier, jsonObject));
+            bindings.Add(new McpParsedBinding(i, bindingType!, identifier, jsonObject)
+            {
+                Metadata = TryParseExistingMetadata(jsonObject)
+            });
         }
 
         return bindings;
+    }
+
+    /// <summary>
+    /// Extracts any pre-existing metadata from the raw binding JSON into a JsonObject
+    /// so that steps can work with the structured model rather than the serialized string.
+    /// </summary>
+    private static JsonObject? TryParseExistingMetadata(JsonObject jsonObject)
+    {
+        if (jsonObject.TryGetPropertyValue("metadata", out var metaNode) && metaNode is not null)
+        {
+            var metaStr = metaNode.GetValue<string>();
+            return JsonNode.Parse(metaStr)?.AsObject();
+        }
+
+        return null;
     }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Extensions.Logging;
@@ -106,19 +107,23 @@ internal sealed class McpBindingBuilder
     /// </summary>
     private static JsonObject? TryParseExistingMetadata(JsonObject jsonObject)
     {
-        try
+        if (!jsonObject.TryGetPropertyValue(McpMetadata, out var metaNode) || metaNode is null)
         {
-            if (jsonObject.TryGetPropertyValue("metadata", out var metaNode) && metaNode is not null)
-            {
-                var metaStr = metaNode.GetValue<string>();
-                return JsonNode.Parse(metaStr)?.AsObject();
-            }
-        }
-        catch
-        {
-            // Malformed metadata is silently ignored; the binding proceeds without it.
+            return null;
         }
 
-        return null;
+        try
+        {
+            var metaStr = metaNode is JsonValue jv
+                ? jv.GetValue<string>()
+                : metaNode.ToJsonString();
+
+            return JsonNode.Parse(metaStr)?.AsObject();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            // Malformed metadata is silently ignored; the binding proceeds without it.
+            return null;
+        }
     }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBuilderContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBuilderContext.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders;
 
@@ -12,19 +14,56 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal sealed class McpBuilderContext
 {
-    public McpBuilderContext(IFunctionMetadata function, List<McpParsedBinding> bindings, ILogger logger, HashSet<string>? sharedEmittedAppTools = null)
+    public McpBuilderContext(
+        IFunctionMetadata function,
+        List<McpParsedBinding> bindings,
+        ILogger logger,
+        IOptionsMonitor<ToolOptions> toolOptions,
+        IOptionsMonitor<ResourceOptions> resourceOptions,
+        IOptionsMonitor<PromptOptions> promptOptions,
+        HashSet<string>? sharedEmittedAppTools = null)
     {
         Function = function;
         Bindings = bindings;
         Logger = logger;
+        ToolOptions = toolOptions;
+        ResourceOptions = resourceOptions;
+        PromptOptions = promptOptions;
         EmittedAppTools = sharedEmittedAppTools ?? [];
+
+        ToolTriggerBindings = bindings.Where(b => b.BindingType == McpToolTriggerBindingType && !string.IsNullOrWhiteSpace(b.Identifier)).ToList();
+        PromptTriggerBindings = bindings.Where(b => b.BindingType == McpPromptTriggerBindingType && !string.IsNullOrWhiteSpace(b.Identifier)).ToList();
+        ResourceTriggerBindings = bindings.Where(b => b.BindingType == McpResourceTriggerBindingType && !string.IsNullOrWhiteSpace(b.Identifier)).ToList();
+        ToolPropertyBindings = bindings.Where(b => b.BindingType == McpToolPropertyBindingType && b.Identifier is not null).ToList();
+        PromptArgumentBindings = bindings.Where(b => b.BindingType == McpPromptArgumentBindingType && b.Identifier is not null).ToList();
     }
 
     public IFunctionMetadata Function { get; }
 
     public List<McpParsedBinding> Bindings { get; }
 
+    /// <summary>Bindings of type <c>mcpToolTrigger</c> with a non-empty identifier.</summary>
+    public IReadOnlyList<McpParsedBinding> ToolTriggerBindings { get; }
+
+    /// <summary>Bindings of type <c>mcpPromptTrigger</c> with a non-empty identifier.</summary>
+    public IReadOnlyList<McpParsedBinding> PromptTriggerBindings { get; }
+
+    /// <summary>Bindings of type <c>mcpResourceTrigger</c> with a non-empty identifier.</summary>
+    public IReadOnlyList<McpParsedBinding> ResourceTriggerBindings { get; }
+
+    /// <summary>Bindings of type <c>mcpToolProperty</c> with a non-null identifier.</summary>
+    public IReadOnlyList<McpParsedBinding> ToolPropertyBindings { get; }
+
+    /// <summary>Bindings of type <c>mcpPromptArgument</c> with a non-null identifier.</summary>
+    public IReadOnlyList<McpParsedBinding> PromptArgumentBindings { get; }
+
     public ILogger Logger { get; }
+
+    public IOptionsMonitor<ToolOptions> ToolOptions { get; }
+
+    public IOptionsMonitor<ResourceOptions> ResourceOptions { get; }
+
+    public IOptionsMonitor<PromptOptions> PromptOptions { get; }
 
     /// <summary>
     /// Tool properties resolved by the AddToolProperties step,

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpParsedBinding.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpParsedBinding.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 
 /// <summary>
 /// Represents a single parsed MCP binding within a function.
+/// Steps collect resolved data on this model; <see cref="McpBindingBuilder.Build"/>
+/// serializes it all onto <see cref="JsonObject"/> in a single pass.
 /// </summary>
 internal sealed class McpParsedBinding(int index, string bindingType, string? identifier, JsonObject jsonObject)
 {
@@ -26,7 +28,30 @@ internal sealed class McpParsedBinding(int index, string bindingType, string? id
     public string? Identifier { get; } = identifier;
 
     /// <summary>
-    /// The parsed JSON object for this binding.
+    /// The parsed JSON object for this binding. Steps should avoid writing to this directly;
+    /// use the pending-change properties below and let <see cref="McpBindingBuilder.Build"/> apply them.
     /// </summary>
     public JsonObject JsonObject { get; } = jsonObject;
+
+    // ── Pending changes: populated by steps, applied by Build() ──
+
+    /// <summary>
+    /// Serialized tool properties JSON, set by AddToolProperties step.
+    /// </summary>
+    public JsonNode? ToolProperties { get; set; }
+
+    /// <summary>
+    /// Serialized prompt arguments JSON, set by AddPromptArguments step.
+    /// </summary>
+    public JsonNode? PromptArguments { get; set; }
+
+    /// <summary>
+    /// Final merged metadata object, assembled by AddMetadata and AddAppUiMetadata steps.
+    /// </summary>
+    public JsonObject? Metadata { get; set; }
+
+    /// <summary>
+    /// Property type string, set by PatchPropertyBindings step for mcpToolProperty bindings.
+    /// </summary>
+    public string? PropertyType { get; set; }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
@@ -52,33 +52,18 @@ internal static class AddAppUiMetadataExtension
 
     private static void MergeUiIntoMetadata(McpBuilderContext context, McpParsedBinding binding, JsonObject uiNode)
     {
-        JsonObject metaObj;
+        binding.Metadata ??= new JsonObject();
 
-        if (binding.JsonObject.TryGetPropertyValue("metadata", out var existingMetaNode)
-            && existingMetaNode is not null)
+        if (binding.Metadata.ContainsKey("ui"))
         {
-            var metaStr = existingMetaNode is JsonValue jsonValue
-                ? jsonValue.GetValue<string>()
-                : existingMetaNode.ToJsonString();
-
-            metaObj = JsonNode.Parse(metaStr) as JsonObject ?? new JsonObject();
-
-            if (metaObj.ContainsKey("ui"))
-            {
-                context.Logger.LogWarning(
-                    "Tool '{ToolName}' defines _meta.ui via McpMetadataAttribute, but the " +
-                    "fluent API also configures UI metadata. The fluent API configuration " +
-                    "will take precedence.",
-                    binding.Identifier);
-            }
-        }
-        else
-        {
-            metaObj = new JsonObject();
+            context.Logger.LogWarning(
+                "Tool '{ToolName}' defines _meta.ui via McpMetadataAttribute, but the " +
+                "fluent API also configures UI metadata. The fluent API configuration " +
+                "will take precedence.",
+                binding.Identifier);
         }
 
-        metaObj["ui"] = uiNode;
-        binding.JsonObject["metadata"] = metaObj.ToJsonString();
+        binding.Metadata["ui"] = uiNode;
     }
 
     /// <summary>

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
+using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -46,7 +47,7 @@ internal static class AddAppUiMetadataExtension
     {
         binding.Metadata ??= new JsonObject();
 
-        if (binding.Metadata.ContainsKey("ui"))
+        if (binding.Metadata.ContainsKey(McpMetadataUi))
         {
             context.Logger.LogWarning(
                 "Tool '{ToolName}' defines _meta.ui via McpMetadataAttribute, but the " +
@@ -55,7 +56,7 @@ internal static class AddAppUiMetadataExtension
                 binding.Identifier);
         }
 
-        binding.Metadata["ui"] = uiNode;
+        binding.Metadata[McpMetadataUi] = uiNode;
     }
 
     /// <summary>
@@ -66,8 +67,8 @@ internal static class AddAppUiMetadataExtension
     {
         var ui = new JsonObject
         {
-            ["resourceUri"] = McpAppUtilities.ResourceUri(toolName),
-            ["visibility"] = SerializeVisibility(appOptions.Visibility)
+            [McpUiResourceUri] = McpAppUtilities.ResourceUri(toolName),
+            [McpUiVisibility] = SerializeVisibility(appOptions.Visibility)
         };
 
         return ui;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
@@ -3,8 +3,6 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -13,19 +11,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal static class AddAppUiMetadataExtension
 {
-    public static McpBindingBuilder AddAppUiMetadata(this McpBindingBuilder builder, IOptionsMonitor<ToolOptions> toolOptions)
+    public static McpBindingBuilder AddAppUiMetadata(this McpBindingBuilder builder)
     {
         var context = builder.Context;
 
-        foreach (var binding in context.Bindings)
+        foreach (var binding in context.ToolTriggerBindings)
         {
-            if (binding.BindingType != McpToolTriggerBindingType
-                || string.IsNullOrWhiteSpace(binding.Identifier))
-            {
-                continue;
-            }
-
-            var options = toolOptions.Get(binding.Identifier);
+            var options = context.ToolOptions.Get(binding.Identifier!);
 
             if (options.AppOptions is null)
             {
@@ -35,14 +27,14 @@ internal static class AddAppUiMetadataExtension
             // Build the tool's _meta.ui per the MCP Apps spec (SEP-1865):
             // Only resourceUri and visibility go on the tool metadata.
             // CSP, permissions, border, domain go on the resource response.
-            var uiNode = BuildToolUiMetadata(binding.Identifier, options.AppOptions);
+            var uiNode = BuildToolUiMetadata(binding.Identifier!, options.AppOptions);
 
             MergeUiIntoMetadata(context, binding, uiNode);
 
             // Emit synthetic resource function for view serving (once per tool name)
-            if (context.EmittedAppTools.Add(binding.Identifier))
+            if (context.EmittedAppTools.Add(binding.Identifier!))
             {
-                context.SyntheticFunctions.Add(McpAppFunctionMetadataFactory.CreateViewResourceFunction(binding.Identifier));
+                context.SyntheticFunctions.Add(McpAppFunctionMetadataFactory.CreateViewResourceFunction(binding.Identifier!));
                 context.Logger.LogDebug("Added synthetic MCP App resource function for tool '{ToolName}'.", binding.Identifier);
             }
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
@@ -66,16 +67,21 @@ internal static class AddMetadataExtension
 
         if (options.Metadata.Count > 0)
         {
-            binding.JsonObject["metadata"] = JsonSerializer.Serialize(options.Metadata);
+            binding.Metadata ??= new JsonObject();
+            foreach (var kvp in options.Metadata)
+            {
+                binding.Metadata[kvp.Key] = JsonValue.Create(kvp.Value);
+            }
         }
     }
 
     private static void ApplyOrMergeAttributedMetadata(McpBuilderContext context, McpParsedBinding binding, string attributedMetadataJson, string type)
     {
-        if (binding.JsonObject.ContainsKey("metadata"))
+        if (binding.Metadata is not null)
         {
-            binding.JsonObject["metadata"] = MetadataMerger.MergeMetadata(
-                binding.JsonObject["metadata"]?.GetValue<string>(), attributedMetadataJson, out var overlappingKeys);
+            var fluentJson = binding.Metadata.ToJsonString();
+            var merged = MetadataMerger.MergeMetadata(fluentJson, attributedMetadataJson, out var overlappingKeys);
+            binding.Metadata = JsonNode.Parse(merged)?.AsObject() ?? new JsonObject();
 
             context.Logger.LogTrace("{Type} '{Identifier}' has metadata defined using both the fluent API and [McpMetadata] attributes. Metadata from both sources has been merged.", type, binding.Identifier);
 
@@ -86,7 +92,7 @@ internal static class AddMetadataExtension
         }
         else
         {
-            binding.JsonObject["metadata"] = attributedMetadataJson;
+            binding.Metadata = JsonNode.Parse(attributedMetadataJson)?.AsObject() ?? new JsonObject();
         }
     }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -14,41 +12,34 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal static class AddMetadataExtension
 {
-    public static McpBindingBuilder AddMetadata(
-        this McpBindingBuilder builder,
-        IOptionsMonitor<ToolOptions> toolOptions,
-        IOptionsMonitor<ResourceOptions> resourceOptions,
-        IOptionsMonitor<PromptOptions> promptOptions)
+    public static McpBindingBuilder AddMetadata(this McpBindingBuilder builder)
     {
         var context = builder.Context;
 
-        foreach (var binding in context.Bindings)
+        foreach (var binding in context.ToolTriggerBindings)
         {
-            switch (binding.BindingType)
+            ApplyFluentMetadata(binding, context.ToolOptions);
+            if (MetadataParser.TryGetToolMetadata(context.Function, out var toolMetadataJson))
             {
-                case McpToolTriggerBindingType:
-                    ApplyFluentMetadata(binding, toolOptions);
-                    if (MetadataParser.TryGetToolMetadata(context.Function, out var toolMetadataJson))
-                    {
-                        ApplyOrMergeAttributedMetadata(context, binding, toolMetadataJson, "Tool");
-                    }
-                    break;
+                ApplyOrMergeAttributedMetadata(context, binding, toolMetadataJson, "Tool");
+            }
+        }
 
-                case McpResourceTriggerBindingType:
-                    ApplyFluentMetadata(binding, resourceOptions);
-                    if (MetadataParser.TryGetResourceMetadata(context.Function, out var resourceMetadataJson))
-                    {
-                        ApplyOrMergeAttributedMetadata(context, binding, resourceMetadataJson, "Resource");
-                    }
-                    break;
+        foreach (var binding in context.ResourceTriggerBindings)
+        {
+            ApplyFluentMetadata(binding, context.ResourceOptions);
+            if (MetadataParser.TryGetResourceMetadata(context.Function, out var resourceMetadataJson))
+            {
+                ApplyOrMergeAttributedMetadata(context, binding, resourceMetadataJson, "Resource");
+            }
+        }
 
-                case McpPromptTriggerBindingType:
-                    ApplyFluentMetadata(binding, promptOptions);
-                    if (MetadataParser.TryGetPromptMetadata(context.Function, out var promptMetadataJson))
-                    {
-                        ApplyOrMergeAttributedMetadata(context, binding, promptMetadataJson, "Prompt");
-                    }
-                    break;
+        foreach (var binding in context.PromptTriggerBindings)
+        {
+            ApplyFluentMetadata(binding, context.PromptOptions);
+            if (MetadataParser.TryGetPromptMetadata(context.Function, out var promptMetadataJson))
+            {
+                ApplyOrMergeAttributedMetadata(context, binding, promptMetadataJson, "Prompt");
             }
         }
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddMetadataExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -61,7 +62,7 @@ internal static class AddMetadataExtension
             binding.Metadata ??= new JsonObject();
             foreach (var kvp in options.Metadata)
             {
-                binding.Metadata[kvp.Key] = JsonValue.Create(kvp.Value);
+                binding.Metadata[kvp.Key] = JsonSerializer.SerializeToNode(kvp.Value);
             }
         }
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddPromptArgumentsExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddPromptArgumentsExtension.cs
@@ -25,7 +25,7 @@ internal static class AddPromptArgumentsExtension
 
             if (TryResolvePromptArguments(context, binding.Identifier, promptOptions, out var promptArguments))
             {
-                binding.JsonObject["promptArguments"] = PromptArgumentParser.GetArgumentsJson(promptArguments);
+                binding.PromptArguments = PromptArgumentParser.GetArgumentsJson(promptArguments);
                 context.ResolvedPromptArguments = promptArguments;
             }
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddPromptArgumentsExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddPromptArgumentsExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Options;
-using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -11,19 +10,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal static class AddPromptArgumentsExtension
 {
-    public static McpBindingBuilder AddPromptArguments(this McpBindingBuilder builder, IOptionsMonitor<PromptOptions> promptOptions)
+    public static McpBindingBuilder AddPromptArguments(this McpBindingBuilder builder)
     {
         var context = builder.Context;
 
-        foreach (var binding in context.Bindings)
+        foreach (var binding in context.PromptTriggerBindings)
         {
-            if (binding.BindingType != McpPromptTriggerBindingType
-                || string.IsNullOrWhiteSpace(binding.Identifier))
-            {
-                continue;
-            }
-
-            if (TryResolvePromptArguments(context, binding.Identifier, promptOptions, out var promptArguments))
+            if (TryResolvePromptArguments(context, binding.Identifier!, context.PromptOptions, out var promptArguments))
             {
                 binding.PromptArguments = PromptArgumentParser.GetArgumentsJson(promptArguments);
                 context.ResolvedPromptArguments = promptArguments;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddToolPropertiesExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddToolPropertiesExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Options;
-using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -11,19 +10,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders
 /// </summary>
 internal static class AddToolPropertiesExtension
 {
-    public static McpBindingBuilder AddToolProperties(this McpBindingBuilder builder, IOptionsMonitor<ToolOptions> toolOptions)
+    public static McpBindingBuilder AddToolProperties(this McpBindingBuilder builder)
     {
         var context = builder.Context;
 
-        foreach (var binding in context.Bindings)
+        foreach (var binding in context.ToolTriggerBindings)
         {
-            if (binding.BindingType != McpToolTriggerBindingType
-                || string.IsNullOrWhiteSpace(binding.Identifier))
-            {
-                continue;
-            }
-
-            if (TryResolveToolProperties(context, binding.Identifier, toolOptions, out var toolProperties))
+            if (TryResolveToolProperties(context, binding.Identifier!, context.ToolOptions, out var toolProperties))
             {
                 binding.ToolProperties = ToolPropertyParser.GetPropertiesJson(toolProperties);
                 context.ResolvedToolProperties = toolProperties;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddToolPropertiesExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddToolPropertiesExtension.cs
@@ -25,7 +25,7 @@ internal static class AddToolPropertiesExtension
 
             if (TryResolveToolProperties(context, binding.Identifier, toolOptions, out var toolProperties))
             {
-                binding.JsonObject["toolProperties"] = ToolPropertyParser.GetPropertiesJson(toolProperties);
+                binding.ToolProperties = ToolPropertyParser.GetPropertiesJson(toolProperties);
                 context.ResolvedToolProperties = toolProperties;
             }
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/PatchPropertyBindingsExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/PatchPropertyBindingsExtension.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
-
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
 /// <summary>
@@ -19,19 +17,10 @@ internal static class PatchPropertyBindingsExtension
             return builder;
         }
 
-        Dictionary<string, McpParsedBinding>? propertyBindings = null;
-
-        foreach (var binding in context.Bindings)
+        if (context.ToolPropertyBindings.Count > 0)
         {
-            if (binding.BindingType == McpToolPropertyBindingType && binding.Identifier is not null)
-            {
-                propertyBindings ??= [];
-                propertyBindings.TryAdd(binding.Identifier, binding);
-            }
-        }
+            var propertyBindings = context.ToolPropertyBindings.ToDictionary(b => b.Identifier!, b => b);
 
-        if (propertyBindings is not null)
-        {
             foreach (var property in context.ResolvedToolProperties)
             {
                 if (propertyBindings.TryGetValue(property.Name, out var binding))

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/PatchPropertyBindingsExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/PatchPropertyBindingsExtension.cs
@@ -36,7 +36,7 @@ internal static class PatchPropertyBindingsExtension
             {
                 if (propertyBindings.TryGetValue(property.Name, out var binding))
                 {
-                    binding.JsonObject[McpToolPropertyType] = property.Type;
+                    binding.PropertyType = property.Type;
                 }
             }
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
@@ -32,7 +32,7 @@ internal sealed class McpFunctionMetadataTransformer(
                 continue;
             }
 
-            var builder = new McpBindingBuilder(function, _logger, emittedAppTools);
+            var builder = new McpBindingBuilder(function, _logger, toolOptionsMonitor, resourceOptionsMonitor, promptOptionsMonitor, emittedAppTools);
 
             if (!builder.HasBindings)
             {
@@ -40,10 +40,10 @@ internal sealed class McpFunctionMetadataTransformer(
             }
 
             builder
-                .AddToolProperties(toolOptionsMonitor)
-                .AddPromptArguments(promptOptionsMonitor)
-                .AddMetadata(toolOptionsMonitor, resourceOptionsMonitor, promptOptionsMonitor)
-                .AddAppUiMetadata(toolOptionsMonitor)
+                .AddToolProperties()
+                .AddPromptArguments()
+                .AddMetadata()
+                .AddAppUiMetadata()
                 .PatchPropertyBindings()
                 .Build();
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
@@ -11,6 +11,8 @@ internal static class Constants
     public const string McpToolPropertyBindingType = "mcpToolProperty";
     public const string McpToolPropertyType = "propertyType";
     public const string McpToolPropertyName = "propertyName";
+    public const string McpToolName = "toolName";
+    public const string McpToolProperties = "toolProperties";
 
     // Resource constants
     public const string ResourceInvocationContextKey = "ResourceInvocationContext";
@@ -21,4 +23,16 @@ internal static class Constants
     public const string McpPromptTriggerBindingType = "mcpPromptTrigger";
     public const string McpPromptArgumentBindingType = "mcpPromptArgument";
     public const string McpPromptArgumentName = "argumentName";
+    public const string McpPromptName = "promptName";
+    public const string McpPromptArguments = "promptArguments";
+
+    // Binding JSON property keys
+    public const string BindingType = "type";
+    public const string McpUri = "uri";
+    public const string McpMetadata = "metadata";
+
+    // UI metadata keys
+    public const string McpMetadataUi = "ui";
+    public const string McpUiResourceUri = "resourceUri";
+    public const string McpUiVisibility = "visibility";
 }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
@@ -19,10 +19,10 @@ public class AddMetadataExtensionTests : IDisposable
     [Fact]
     public void AddMetadata_FluentMetadataAppliedToToolTrigger()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
         var toolOptions = CreateToolOptions("MyTool", metadata: new Dictionary<string, object> { ["author"] = "Jane" });
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        builder.AddMetadata(toolOptions, CreateResourceOptions(), CreatePromptOptions());
+        builder.AddMetadata();
 
         var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
@@ -32,10 +32,10 @@ public class AddMetadataExtensionTests : IDisposable
     [Fact]
     public void AddMetadata_FluentMetadataAppliedToResourceTrigger()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpResourceTrigger\",\"uri\":\"file://test\"}");
         var resourceOptions = CreateResourceOptions("file://test", new Dictionary<string, object> { ["source"] = "local" });
+        var builder = CreateBuilder(CreateToolOptions(), resourceOptions, CreatePromptOptions(), "{\"type\":\"mcpResourceTrigger\",\"uri\":\"file://test\"}");
 
-        builder.AddMetadata(CreateToolOptions(), resourceOptions, CreatePromptOptions());
+        builder.AddMetadata();
 
         var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
@@ -45,10 +45,10 @@ public class AddMetadataExtensionTests : IDisposable
     [Fact]
     public void AddMetadata_FluentMetadataAppliedToPromptTrigger()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpPromptTrigger\",\"promptName\":\"MyPrompt\"}");
         var promptOptions = CreatePromptOptions("MyPrompt", metadata: new Dictionary<string, object> { ["version"] = "1.0" });
+        var builder = CreateBuilder(CreateToolOptions(), CreateResourceOptions(), promptOptions, "{\"type\":\"mcpPromptTrigger\",\"promptName\":\"MyPrompt\"}");
 
-        builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), promptOptions);
+        builder.AddMetadata();
 
         var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
@@ -60,7 +60,7 @@ public class AddMetadataExtensionTests : IDisposable
     {
         var builder = CreateBuilder("{\"type\":\"mcpToolProperty\",\"propertyName\":\"name\"}");
 
-        builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
+        builder.AddMetadata();
 
         Assert.Null(builder.Context.Bindings[0].Metadata);
     }
@@ -70,7 +70,7 @@ public class AddMetadataExtensionTests : IDisposable
     {
         var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
+        builder.AddMetadata();
 
         Assert.Null(builder.Context.Bindings[0].Metadata);
     }
@@ -87,9 +87,9 @@ public class AddMetadataExtensionTests : IDisposable
             name: "Func",
             bindings: new List<string> { "{\"type\":\"mcpToolTrigger\",\"toolName\":\"WithToolMetadata\"}" });
 
-        var builder = new McpBindingBuilder(fn.Object, NullLogger.Instance);
+        var builder = new McpBindingBuilder(fn.Object, NullLogger.Instance, CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
 
-        builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
+        builder.AddMetadata();
 
         var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
@@ -101,7 +101,7 @@ public class AddMetadataExtensionTests : IDisposable
     {
         var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        var result = builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
+        var result = builder.AddMetadata();
 
         Assert.Same(builder, result);
     }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
@@ -24,9 +24,9 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(toolOptions, CreateResourceOptions(), CreatePromptOptions());
 
-        var metadata = builder.Context.Bindings[0].JsonObject["metadata"]?.ToString();
+        var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
-        Assert.Contains("author", metadata);
+        Assert.Contains("author", metadata.ToJsonString());
     }
 
     [Fact]
@@ -37,9 +37,9 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(CreateToolOptions(), resourceOptions, CreatePromptOptions());
 
-        var metadata = builder.Context.Bindings[0].JsonObject["metadata"]?.ToString();
+        var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
-        Assert.Contains("source", metadata);
+        Assert.Contains("source", metadata.ToJsonString());
     }
 
     [Fact]
@@ -50,9 +50,9 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), promptOptions);
 
-        var metadata = builder.Context.Bindings[0].JsonObject["metadata"]?.ToString();
+        var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
-        Assert.Contains("version", metadata);
+        Assert.Contains("version", metadata.ToJsonString());
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
 
-        Assert.False(builder.Context.Bindings[0].JsonObject.ContainsKey("metadata"));
+        Assert.Null(builder.Context.Bindings[0].Metadata);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
 
-        Assert.False(builder.Context.Bindings[0].JsonObject.ContainsKey("metadata"));
+        Assert.Null(builder.Context.Bindings[0].Metadata);
     }
 
     [Fact]
@@ -91,9 +91,9 @@ public class AddMetadataExtensionTests : IDisposable
 
         builder.AddMetadata(CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
 
-        var metadata = builder.Context.Bindings[0].JsonObject["metadata"]?.ToString();
+        var metadata = builder.Context.Bindings[0].Metadata;
         Assert.NotNull(metadata);
-        Assert.Contains("author", metadata);
+        Assert.Contains("author", metadata.ToJsonString());
     }
 
     [Fact]

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddMetadataExtensionTests.cs
@@ -106,6 +106,46 @@ public class AddMetadataExtensionTests : IDisposable
         Assert.Same(builder, result);
     }
 
+    [Fact]
+    public void AddMetadata_FluentMetadata_SerializesNestedDictionary()
+    {
+        var nested = new Dictionary<string, object>
+        {
+            ["key1"] = "val1",
+            ["key2"] = 42
+        };
+        var toolOptions = CreateToolOptions("MyTool", metadata: new Dictionary<string, object> { ["nested"] = nested });
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
+
+        builder.AddMetadata();
+
+        var metadata = builder.Context.Bindings[0].Metadata;
+        Assert.NotNull(metadata);
+        var nestedNode = metadata["nested"];
+        Assert.NotNull(nestedNode);
+        // Should be a proper JSON object, not a ToString() representation
+        Assert.Equal("val1", nestedNode["key1"]?.GetValue<string>());
+        Assert.Equal(42, nestedNode["key2"]?.GetValue<int>());
+    }
+
+    [Fact]
+    public void AddMetadata_FluentMetadata_SerializesList()
+    {
+        var list = new List<string> { "a", "b", "c" };
+        var toolOptions = CreateToolOptions("MyTool", metadata: new Dictionary<string, object> { ["tags"] = list });
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
+
+        builder.AddMetadata();
+
+        var metadata = builder.Context.Bindings[0].Metadata;
+        Assert.NotNull(metadata);
+        var tagsNode = metadata["tags"];
+        Assert.NotNull(tagsNode);
+        var arr = tagsNode.AsArray();
+        Assert.Equal(3, arr.Count);
+        Assert.Equal("a", arr[0]?.GetValue<string>());
+    }
+
     internal class TestFunctions
     {
         public void WithToolMetadata(

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
@@ -21,7 +21,7 @@ public class AddToolPropertiesExtensionTests : IDisposable
 
         builder.AddToolProperties(toolOptions);
 
-        var tp = builder.Context.Bindings[0].JsonObject["toolProperties"]?.ToString();
+        var tp = builder.Context.Bindings[0].ToolProperties?.ToString();
         Assert.NotNull(tp);
         Assert.Contains("\"propertyName\":\"x\"", tp);
     }
@@ -48,7 +48,7 @@ public class AddToolPropertiesExtensionTests : IDisposable
 
         builder.AddToolProperties(toolOptions);
 
-        Assert.False(builder.Context.Bindings[0].JsonObject.ContainsKey("toolProperties"));
+        Assert.Null(builder.Context.Bindings[0].ToolProperties);
         Assert.Null(builder.Context.ResolvedToolProperties);
     }
 
@@ -60,7 +60,7 @@ public class AddToolPropertiesExtensionTests : IDisposable
 
         builder.AddToolProperties(toolOptions);
 
-        Assert.False(builder.Context.Bindings[0].JsonObject.ContainsKey("toolProperties"));
+        Assert.Null(builder.Context.Bindings[0].ToolProperties);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class AddToolPropertiesExtensionTests : IDisposable
 
         builder.AddToolProperties(toolOptions);
 
-        Assert.False(builder.Context.Bindings[0].JsonObject.ContainsKey("toolProperties"));
+        Assert.Null(builder.Context.Bindings[0].ToolProperties);
     }
 
     [Fact]

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/AddToolPropertiesExtensionTests.cs
@@ -16,10 +16,10 @@ public class AddToolPropertiesExtensionTests : IDisposable
     [Fact]
     public void AddToolProperties_WithConfiguredOptions_SetsToolProperties()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
         var toolOptions = CreateToolOptions("MyTool", [new ToolProperty("x", "string", "desc", true)]);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        builder.AddToolProperties(toolOptions);
+        builder.AddToolProperties();
 
         var tp = builder.Context.Bindings[0].ToolProperties?.ToString();
         Assert.NotNull(tp);
@@ -29,10 +29,10 @@ public class AddToolPropertiesExtensionTests : IDisposable
     [Fact]
     public void AddToolProperties_SetsResolvedToolPropertiesOnContext()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
         var toolOptions = CreateToolOptions("MyTool", [new ToolProperty("x", "string", "desc", true)]);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        builder.AddToolProperties(toolOptions);
+        builder.AddToolProperties();
 
         Assert.NotNull(builder.Context.ResolvedToolProperties);
         Assert.Single(builder.Context.ResolvedToolProperties);
@@ -43,10 +43,10 @@ public class AddToolPropertiesExtensionTests : IDisposable
     public void AddToolProperties_NoOptionsOrAttributes_DoesNotSetToolProperties()
     {
         Environment.SetEnvironmentVariable("FUNCTIONS_APPLICATION_DIRECTORY", Path.GetDirectoryName(typeof(AddToolPropertiesExtensionTests).Assembly.Location));
-        var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
         var toolOptions = CreateToolOptions("MyTool");
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        builder.AddToolProperties(toolOptions);
+        builder.AddToolProperties();
 
         Assert.Null(builder.Context.Bindings[0].ToolProperties);
         Assert.Null(builder.Context.ResolvedToolProperties);
@@ -55,10 +55,10 @@ public class AddToolPropertiesExtensionTests : IDisposable
     [Fact]
     public void AddToolProperties_SkipsNonToolTriggerBindings()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpResourceTrigger\",\"uri\":\"file://test\"}");
         var toolOptions = CreateToolOptions("file://test", [new ToolProperty("x", "string", "desc", true)]);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpResourceTrigger\",\"uri\":\"file://test\"}");
 
-        builder.AddToolProperties(toolOptions);
+        builder.AddToolProperties();
 
         Assert.Null(builder.Context.Bindings[0].ToolProperties);
     }
@@ -66,10 +66,10 @@ public class AddToolPropertiesExtensionTests : IDisposable
     [Fact]
     public void AddToolProperties_SkipsToolTriggerWithBlankIdentifier()
     {
-        var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\" \"}");
         var toolOptions = CreateToolOptions(" ", [new ToolProperty("x", "string", "desc", true)]);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), "{\"type\":\"mcpToolTrigger\",\"toolName\":\" \"}");
 
-        builder.AddToolProperties(toolOptions);
+        builder.AddToolProperties();
 
         Assert.Null(builder.Context.Bindings[0].ToolProperties);
     }
@@ -80,7 +80,7 @@ public class AddToolPropertiesExtensionTests : IDisposable
         Environment.SetEnvironmentVariable("FUNCTIONS_APPLICATION_DIRECTORY", Path.GetDirectoryName(typeof(AddToolPropertiesExtensionTests).Assembly.Location));
         var builder = CreateBuilder("{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"}");
 
-        var result = builder.AddToolProperties(CreateToolOptions());
+        var result = builder.AddToolProperties();
 
         Assert.Same(builder, result);
     }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/McpBindingBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/McpBindingBuilderTests.cs
@@ -121,7 +121,7 @@ public class McpBindingBuilderTests
     {
         var httpBinding = "{\"type\":\"httpTrigger\",\"direction\":\"in\"}";
         var fn = CreateFunctionMetadata(bindings: new List<string> { httpBinding, "{\"type\":\"mcpToolTrigger\",\"toolName\":\"Tool\"}" });
-        var builder = new McpBindingBuilder(fn.Object, NullLogger.Instance);
+        var builder = new McpBindingBuilder(fn.Object, NullLogger.Instance, CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
 
         builder.Build();
 

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/McpBindingBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/McpBindingBuilderTests.cs
@@ -127,4 +127,17 @@ public class McpBindingBuilderTests
 
         Assert.Equal(httpBinding, fn.Object.RawBindings![0]);
     }
+
+    [Fact]
+    public void ParseBindings_HandlesStructuredMetadataObject()
+    {
+        var raw = "{\"type\":\"mcpToolTrigger\",\"toolName\":\"MyTool\"," +
+                  "\"metadata\":{\"category\":\"search\"}}";
+        var builder = CreateBuilder(raw);
+
+        Assert.Single(builder.Context.Bindings);
+        var metadata = builder.Context.Bindings[0].Metadata;
+        Assert.NotNull(metadata);
+        Assert.Equal("search", metadata["category"]?.GetValue<string>());
+    }
 }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/PatchPropertyBindingsExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/PatchPropertyBindingsExtensionTests.cs
@@ -21,7 +21,7 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Equal("integer", builder.Context.Bindings[1].JsonObject["propertyType"]?.ToString());
+        Assert.Equal("integer", builder.Context.Bindings[1].PropertyType);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Null(builder.Context.Bindings[1].JsonObject["propertyType"]);
+        Assert.Null(builder.Context.Bindings[1].PropertyType);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Null(builder.Context.Bindings[0].JsonObject["propertyType"]);
+        Assert.Null(builder.Context.Bindings[0].PropertyType);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Null(builder.Context.Bindings[0].JsonObject["propertyType"]);
+        Assert.Null(builder.Context.Bindings[0].PropertyType);
     }
 
     [Fact]
@@ -79,9 +79,9 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Equal("string", builder.Context.Bindings[1].JsonObject["propertyType"]?.ToString());
-        Assert.Equal("integer", builder.Context.Bindings[2].JsonObject["propertyType"]?.ToString());
-        Assert.Null(builder.Context.Bindings[3].JsonObject["propertyType"]);
+        Assert.Equal("string", builder.Context.Bindings[1].PropertyType);
+        Assert.Equal("integer", builder.Context.Bindings[2].PropertyType);
+        Assert.Null(builder.Context.Bindings[3].PropertyType);
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public class PatchPropertyBindingsExtensionTests
 
         builder.PatchPropertyBindings();
 
-        Assert.Null(builder.Context.Bindings[0].JsonObject["propertyType"]);
-        Assert.Equal("string", builder.Context.Bindings[1].JsonObject["propertyType"]?.ToString());
+        Assert.Null(builder.Context.Bindings[0].PropertyType);
+        Assert.Equal("string", builder.Context.Bindings[1].PropertyType);
     }
 
     [Fact]

--- a/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
@@ -16,7 +16,17 @@ internal static class BuilderTestHelper
     public static McpBindingBuilder CreateBuilder(params string[] bindings)
     {
         var fn = CreateFunctionMetadata(bindings: bindings);
-        return new McpBindingBuilder(fn.Object, NullLogger.Instance);
+        return new McpBindingBuilder(fn.Object, NullLogger.Instance, CreateToolOptions(), CreateResourceOptions(), CreatePromptOptions());
+    }
+
+    public static McpBindingBuilder CreateBuilder(
+        IOptionsMonitor<ToolOptions> toolOptions,
+        IOptionsMonitor<ResourceOptions> resourceOptions,
+        IOptionsMonitor<PromptOptions> promptOptions,
+        params string[] bindings)
+    {
+        var fn = CreateFunctionMetadata(bindings: bindings);
+        return new McpBindingBuilder(fn.Object, NullLogger.Instance, toolOptions, resourceOptions, promptOptions);
     }
 
     public static Mock<IFunctionMetadata> CreateFunctionMetadata(


### PR DESCRIPTION
Refactor McpBindingBuilder so pipeline steps collect resolved data on McpParsedBinding model properties instead of mutating binding.JsonObject directly. Build() is now the single serialization point that applies all pending changes and serializes each binding once.

Changes:
- Add ToolProperties, PromptArguments, Metadata, PropertyType properties to McpParsedBinding as pending-change slots
- Seed binding.Metadata from any pre-existing metadata in raw binding JSON during ParseBindings() so steps can work with structured data
- Refactor all 5 steps (AddToolProperties, AddPromptArguments, AddMetadata, AddAppUiMetadata, PatchPropertyBindings) to write to model properties
- Build() applies all collected data to JsonObject in one pass, then serializes to RawBindings
- Update unit tests to assert on model properties instead of JsonObject
- AddAppUiMetadata.MergeUiIntoMetadata simplified from 15 to 7 lines by working directly with binding.Metadata JsonObject

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
