### PR TITLE
 Extract raw JSON property name strings into named constants

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Configuration/McpUseResultSchemaTransformer.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
+using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 
@@ -44,7 +45,7 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
                 }
 
                 // Check binding type
-                if (jsonObject.TryGetPropertyValue("type", out var typeNode))
+                if (jsonObject.TryGetPropertyValue(BindingType, out var typeNode))
                 {
                     var bindingType = typeNode?.ToString();
                     if (string.Equals(bindingType, McpToolTriggerBindingType, StringComparison.OrdinalIgnoreCase))
@@ -78,10 +79,10 @@ public sealed class McpUseResultSchemaTransformer : IFunctionMetadataTransformer
             }
 
             // Check if direction is "out"
-            if (jsonObject.TryGetPropertyValue("direction", out var directionNode))
+            if (jsonObject.TryGetPropertyValue(BindingDirectionProperty, out var directionNode))
             {
                 var direction = directionNode?.ToString();
-                if (string.Equals(direction, "out", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(direction, BindingDirectionOut, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Constants.cs
@@ -12,4 +12,9 @@ internal static class Constants
     public const string TextContextResult = "text";
 
     public const string CallToolResultType = "call_tool_result";
+
+    // Binding JSON property keys
+    public const string BindingType = "type";
+    public const string BindingDirectionProperty = "direction";
+    public const string BindingDirectionOut = "out";
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -39,17 +39,17 @@ internal sealed class McpBindingBuilder
         {
             if (binding.ToolProperties is not null)
             {
-                binding.JsonObject["toolProperties"] = binding.ToolProperties;
+                binding.JsonObject[McpToolProperties] = binding.ToolProperties;
             }
 
             if (binding.PromptArguments is not null)
             {
-                binding.JsonObject["promptArguments"] = binding.PromptArguments;
+                binding.JsonObject[McpPromptArguments] = binding.PromptArguments;
             }
 
             if (binding.Metadata is not null)
             {
-                binding.JsonObject["metadata"] = binding.Metadata.ToJsonString();
+                binding.JsonObject[McpMetadata] = binding.Metadata.ToJsonString();
             }
 
             if (binding.PropertyType is not null)
@@ -70,7 +70,7 @@ internal sealed class McpBindingBuilder
             var node = JsonNode.Parse(function.RawBindings[i]);
 
             if (node is not JsonObject jsonObject
-                || !jsonObject.TryGetPropertyValue("type", out var bindingTypeNode))
+                || !jsonObject.TryGetPropertyValue(BindingType, out var bindingTypeNode))
             {
                 continue;
             }
@@ -79,9 +79,9 @@ internal sealed class McpBindingBuilder
 
             string? identifier = bindingType switch
             {
-                McpToolTriggerBindingType => jsonObject["toolName"]?.ToString(),
-                McpResourceTriggerBindingType => jsonObject["uri"]?.ToString(),
-                McpPromptTriggerBindingType => jsonObject["promptName"]?.ToString(),
+                McpToolTriggerBindingType => jsonObject[McpToolName]?.ToString(),
+                McpResourceTriggerBindingType => jsonObject[McpUri]?.ToString(),
+                McpPromptTriggerBindingType => jsonObject[McpPromptName]?.ToString(),
                 McpToolPropertyBindingType => jsonObject[McpToolPropertyName]?.ToString(),
                 McpPromptArgumentBindingType => jsonObject[McpPromptArgumentName]?.ToString(),
                 _ => null,

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/AddAppUiMetadataExtension.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
+using static Microsoft.Azure.Functions.Worker.Extensions.Mcp.Constants;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
@@ -46,7 +47,7 @@ internal static class AddAppUiMetadataExtension
     {
         binding.Metadata ??= new JsonObject();
 
-        if (binding.Metadata.ContainsKey("ui"))
+        if (binding.Metadata.ContainsKey(McpMetadataUi))
         {
             context.Logger.LogWarning(
                 "Tool '{ToolName}' defines _meta.ui via McpMetadataAttribute, but the " +
@@ -55,7 +56,7 @@ internal static class AddAppUiMetadataExtension
                 binding.Identifier);
         }
 
-        binding.Metadata["ui"] = uiNode;
+        binding.Metadata[McpMetadataUi] = uiNode;
     }
 
     /// <summary>
@@ -66,8 +67,8 @@ internal static class AddAppUiMetadataExtension
     {
         var ui = new JsonObject
         {
-            ["resourceUri"] = McpAppUtilities.ResourceUri(toolName),
-            ["visibility"] = SerializeVisibility(appOptions.Visibility)
+            [McpUiResourceUri] = McpAppUtilities.ResourceUri(toolName),
+            [McpUiVisibility] = SerializeVisibility(appOptions.Visibility)
         };
 
         return ui;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
@@ -11,6 +11,8 @@ internal static class Constants
     public const string McpToolPropertyBindingType = "mcpToolProperty";
     public const string McpToolPropertyType = "propertyType";
     public const string McpToolPropertyName = "propertyName";
+    public const string McpToolName = "toolName";
+    public const string McpToolProperties = "toolProperties";
 
     // Resource constants
     public const string ResourceInvocationContextKey = "ResourceInvocationContext";
@@ -21,4 +23,16 @@ internal static class Constants
     public const string McpPromptTriggerBindingType = "mcpPromptTrigger";
     public const string McpPromptArgumentBindingType = "mcpPromptArgument";
     public const string McpPromptArgumentName = "argumentName";
+    public const string McpPromptName = "promptName";
+    public const string McpPromptArguments = "promptArguments";
+
+    // Binding JSON property keys
+    public const string BindingType = "type";
+    public const string McpUri = "uri";
+    public const string McpMetadata = "metadata";
+
+    // UI metadata keys
+    public const string McpMetadataUi = "ui";
+    public const string McpUiResourceUri = "resourceUri";
+    public const string McpUiVisibility = "visibility";
 }


### PR DESCRIPTION
Replaces ~12 raw string literals with named constants across [McpBindingBuilder.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [AddAppUiMetadataExtension.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [McpUseResultSchemaTransformer.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). New constants added to both [Constants.cs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) files. Follow-up to #239.