### PR TITLE
Add input schema support for the worker extension

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/InputSchemaValidator.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/InputSchemaValidator.cs
@@ -53,14 +53,12 @@ internal static class InputSchemaValidator
         }
 
         if (root.TryGetPropertyValue("properties", out var propsNode)
-            && propsNode is not null
             && propsNode is not JsonObject)
         {
             throw new ArgumentException("Input schema \"properties\" must be a JSON object when present.", paramName);
         }
 
         if (root.TryGetPropertyValue("required", out var requiredNode)
-            && requiredNode is not null
             && requiredNode is not JsonArray)
         {
             throw new ArgumentException("Input schema \"required\" must be a JSON array when present.", paramName);

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/InputSchemaValidator.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/InputSchemaValidator.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+/// <summary>
+/// Validates that a JSON input schema conforms to the MCP tool input-schema shape
+/// expected by the host (mirrors <c>McpInputSchemaJsonUtilities.IsValidMcpToolSchema</c>).
+/// </summary>
+internal static class InputSchemaValidator
+{
+    /// <summary>
+    /// Parses <paramref name="jsonSchema"/> and validates its shape.
+    /// </summary>
+    /// <param name="jsonSchema">JSON schema string.</param>
+    /// <param name="paramName">Parameter name used in thrown exceptions.</param>
+    /// <returns>The parsed <see cref="JsonNode"/> on success.</returns>
+    /// <exception cref="ArgumentException">Thrown when the schema is null/empty, not an object, or violates MCP shape rules.</exception>
+    /// <exception cref="JsonException">Thrown when the schema is not valid JSON.</exception>
+    public static JsonNode ValidateAndParse(string jsonSchema, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jsonSchema, paramName);
+
+        var node = JsonNode.Parse(jsonSchema)
+            ?? throw new ArgumentException("Input schema must be a JSON object.", paramName);
+
+        Validate(node, paramName);
+        return node;
+    }
+
+    /// <summary>
+    /// Validates a parsed schema node.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the schema does not match MCP requirements.</exception>
+    public static void Validate(JsonNode schemaNode, string paramName)
+    {
+        ArgumentNullException.ThrowIfNull(schemaNode, paramName);
+
+        if (schemaNode is not JsonObject root)
+        {
+            throw new ArgumentException("Input schema must be a JSON object.", paramName);
+        }
+
+        if (!root.TryGetPropertyValue("type", out var typeNode)
+            || typeNode is not JsonValue typeValue
+            || !typeValue.TryGetValue<string>(out var typeStr)
+            || typeStr != "object")
+        {
+            throw new ArgumentException("Input schema must have a root \"type\" property with value \"object\".", paramName);
+        }
+
+        if (root.TryGetPropertyValue("properties", out var propsNode)
+            && propsNode is not null
+            && propsNode is not JsonObject)
+        {
+            throw new ArgumentException("Input schema \"properties\" must be a JSON object when present.", paramName);
+        }
+
+        if (root.TryGetPropertyValue("required", out var requiredNode)
+            && requiredNode is not null
+            && requiredNode is not JsonArray)
+        {
+            throw new ArgumentException("Input schema \"required\" must be a JSON array when present.", paramName);
+        }
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpBindingBuilder.cs
@@ -57,6 +57,16 @@ internal sealed class McpBindingBuilder
                 binding.JsonObject[McpToolPropertyType] = binding.PropertyType;
             }
 
+            if (binding.InputSchema is not null)
+            {
+                binding.JsonObject[McpInputSchema] = binding.InputSchema;
+            }
+
+            if (binding.UseWorkerInputSchema)
+            {
+                binding.JsonObject[McpUseWorkerInputSchema] = true;
+            }
+
             Context.Function.RawBindings![binding.Index] = binding.JsonObject.ToJsonString();
         }
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpParsedBinding.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/McpParsedBinding.cs
@@ -54,4 +54,15 @@ internal sealed class McpParsedBinding(int index, string bindingType, string? id
     /// Property type string, set by PatchPropertyBindings step for mcpToolProperty bindings.
     /// </summary>
     public string? PropertyType { get; set; }
+
+    /// <summary>
+    /// Serialized JSON input schema, set by ResolveToolInputSchema step for mcpToolTrigger bindings.
+    /// </summary>
+    public string? InputSchema { get; set; }
+
+    /// <summary>
+    /// When true, the worker has provided an explicit input schema and the host should use
+    /// it instead of generating one from <c>toolProperties</c>. Set by ResolveToolInputSchema.
+    /// </summary>
+    public bool UseWorkerInputSchema { get; set; }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
-
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 
 /// <summary>
@@ -20,6 +17,8 @@ internal static class ResolveToolInputSchemaExtension
 {
     public static McpBindingBuilder ResolveToolInputSchema(this McpBindingBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         var context = builder.Context;
 
         foreach (var binding in context.ToolTriggerBindings)
@@ -27,27 +26,12 @@ internal static class ResolveToolInputSchemaExtension
             var toolName = binding.Identifier!;
             var options = context.ToolOptions.Get(toolName);
 
-            var explicitSchema = options.InputSchema;
-            if (string.IsNullOrWhiteSpace(explicitSchema))
+            if (options.InputSchema is null)
             {
                 continue;
             }
 
-            // The schema was already validated by McpToolBuilder.WithInputSchema.
-            // Re-validate defensively in case ToolOptions was mutated directly.
-            try
-            {
-                _ = InputSchemaValidator.ValidateAndParse(explicitSchema, nameof(ToolOptions.InputSchema));
-            }
-            catch (Exception ex) when (ex is ArgumentException or JsonException)
-            {
-                context.Logger.LogWarning(ex,
-                    "Explicit input schema for tool '{ToolName}' is invalid and will be ignored.",
-                    toolName);
-                continue;
-            }
-
-            binding.InputSchema = explicitSchema;
+            binding.InputSchema = options.InputSchema.Json;
             binding.UseWorkerInputSchema = true;
         }
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpBindingBuilder/Steps/ResolveToolInputSchemaExtension.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
+
+/// <summary>
+/// For each <c>mcpToolTrigger</c> binding, applies an explicit input schema configured
+/// via <c>McpToolBuilder.WithInputSchema(...)</c> and signals the host to use it
+/// (<c>useWorkerInputSchema = true</c>).
+///
+/// <para>
+/// When no explicit schema is configured, this step is a no-op and the host continues
+/// to generate a schema from <c>toolProperties</c> as before.
+/// </para>
+/// </summary>
+internal static class ResolveToolInputSchemaExtension
+{
+    public static McpBindingBuilder ResolveToolInputSchema(this McpBindingBuilder builder)
+    {
+        var context = builder.Context;
+
+        foreach (var binding in context.ToolTriggerBindings)
+        {
+            var toolName = binding.Identifier!;
+            var options = context.ToolOptions.Get(toolName);
+
+            var explicitSchema = options.InputSchema;
+            if (string.IsNullOrWhiteSpace(explicitSchema))
+            {
+                continue;
+            }
+
+            // The schema was already validated by McpToolBuilder.WithInputSchema.
+            // Re-validate defensively in case ToolOptions was mutated directly.
+            try
+            {
+                _ = InputSchemaValidator.ValidateAndParse(explicitSchema, nameof(ToolOptions.InputSchema));
+            }
+            catch (Exception ex) when (ex is ArgumentException or JsonException)
+            {
+                context.Logger.LogWarning(ex,
+                    "Explicit input schema for tool '{ToolName}' is invalid and will be ignored.",
+                    toolName);
+                continue;
+            }
+
+            binding.InputSchema = explicitSchema;
+            binding.UseWorkerInputSchema = true;
+        }
+
+        return builder;
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpFunctionMetadataTransformer.cs
@@ -45,6 +45,7 @@ internal sealed class McpFunctionMetadataTransformer(
                 .AddMetadata()
                 .AddAppUiMetadata()
                 .PatchPropertyBindings()
+                .ResolveToolInputSchema()
                 .Build();
 
             syntheticFunctions.AddRange(builder.Context.SyntheticFunctions);

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpInputSchema.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpInputSchema.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+namespace Microsoft.Azure.Functions.Worker.Builder;
+
+/// <summary>
+/// A strongly-typed, validated MCP tool input JSON schema.
+/// An <see cref="McpInputSchema"/> instance can only exist when the schema
+/// conforms to the MCP tool input-schema shape expected by the host — once constructed,
+/// consumers can use <see cref="Json"/> without re-validating.
+/// </summary>
+public sealed class McpInputSchema
+{
+    /// <summary>
+    /// Initializes a new instance from a JSON schema string.
+    /// </summary>
+    /// <param name="json">A valid JSON schema string with root <c>"type": "object"</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when the schema is null/empty or violates MCP shape rules.</exception>
+    /// <exception cref="JsonException">Thrown when the schema is not valid JSON.</exception>
+    public McpInputSchema(string json)
+    {
+        var node = InputSchemaValidator.ValidateAndParse(json, nameof(json));
+        Json = node.ToJsonString();
+    }
+
+    /// <summary>
+    /// Initializes a new instance from a <see cref="JsonNode"/>.
+    /// </summary>
+    /// <param name="schemaNode">A <see cref="JsonNode"/> representing a valid JSON schema.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="schemaNode"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the schema does not conform to MCP requirements.</exception>
+    public McpInputSchema(JsonNode schemaNode)
+    {
+        ArgumentNullException.ThrowIfNull(schemaNode);
+        InputSchemaValidator.Validate(schemaNode, nameof(schemaNode));
+        Json = schemaNode.ToJsonString();
+    }
+
+    /// <summary>
+    /// The canonical JSON representation of the schema.
+    /// </summary>
+    public string Json { get; }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpInputSchema.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/McpInputSchema.cs
@@ -44,4 +44,9 @@ public sealed class McpInputSchema
     /// The canonical JSON representation of the schema.
     /// </summary>
     public string Json { get; }
+
+    /// <summary>
+    /// Returns the canonical JSON representation of the schema.
+    /// </summary>
+    public override string ToString() => Json;
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
@@ -51,5 +51,5 @@ public class ToolOptions : McpBuilderOptions
     /// on the tool trigger binding, taking precedence over any host-side schema
     /// generated from <see cref="Properties"/>.
     /// </summary>
-    public string? InputSchema { get; set; }
+    public McpInputSchema? InputSchema { get; set; }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptions.cs
@@ -44,4 +44,12 @@ public class ToolOptions : McpBuilderOptions
     /// MCP App configuration for this tool. Null if this tool is not an MCP App.
     /// </summary>
     public AppOptions? AppOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets an explicit JSON input schema for the tool.
+    /// When set, the worker emits this schema (and <c>useWorkerInputSchema = true</c>)
+    /// on the tool trigger binding, taking precedence over any host-side schema
+    /// generated from <see cref="Properties"/>.
+    /// </summary>
+    public string? InputSchema { get; set; }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Constants.cs
@@ -13,6 +13,8 @@ internal static class Constants
     public const string McpToolPropertyName = "propertyName";
     public const string McpToolName = "toolName";
     public const string McpToolProperties = "toolProperties";
+    public const string McpInputSchema = "inputSchema";
+    public const string McpUseWorkerInputSchema = "useWorkerInputSchema";
 
     // Resource constants
     public const string ResourceInvocationContextKey = "ResourceInvocationContext";

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
@@ -4,6 +4,7 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.ComponentModel;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.Azure.Functions.Worker.Builder;
 
@@ -59,6 +60,51 @@ public sealed class McpToolBuilder(IFunctionsWorkerApplicationBuilder builder, s
 
             configure(appBuilder);
         });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets an explicit JSON input schema for this MCP tool. The schema is validated
+    /// to ensure it has root <c>"type": "object"</c> (and that <c>properties</c>/<c>required</c>
+    /// have the correct shapes when present). When set, the worker emits this schema and
+    /// signals the host (via <c>useWorkerInputSchema = true</c>) to use it instead of
+    /// generating one from <c>toolProperties</c>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WithInputSchema(string)"/> may be combined with <see cref="WithProperty(string, McpToolPropertyType, string, bool)"/>;
+    /// the explicit schema takes precedence on hosts that understand it, while older hosts
+    /// continue to consume <c>toolProperties</c>.
+    /// </remarks>
+    /// <param name="jsonSchema">A valid JSON schema string defining the tool's input parameters.</param>
+    /// <returns>The current <see cref="McpToolBuilder"/> instance, enabling fluent configuration.</returns>
+    /// <exception cref="ArgumentException">Thrown when the schema is null/empty or does not conform to MCP requirements.</exception>
+    /// <exception cref="System.Text.Json.JsonException">Thrown when the schema string is not valid JSON.</exception>
+    public McpToolBuilder WithInputSchema(string jsonSchema)
+    {
+        InputSchemaValidator.ValidateAndParse(jsonSchema, nameof(jsonSchema));
+
+        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = jsonSchema);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets an explicit JSON input schema for this MCP tool from a <see cref="JsonNode"/>.
+    /// See <see cref="WithInputSchema(string)"/> for details.
+    /// </summary>
+    /// <param name="schemaNode">A <see cref="JsonNode"/> representing a valid JSON schema.</param>
+    /// <returns>The current <see cref="McpToolBuilder"/> instance, enabling fluent configuration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="schemaNode"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the schema does not conform to MCP requirements.</exception>
+    public McpToolBuilder WithInputSchema(JsonNode schemaNode)
+    {
+        ArgumentNullException.ThrowIfNull(schemaNode, nameof(schemaNode));
+
+        InputSchemaValidator.Validate(schemaNode, nameof(schemaNode));
+
+        var schemaJson = schemaNode.ToJsonString();
+        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = schemaJson);
 
         return this;
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/DependencyInjection/McpToolBuilder.cs
@@ -82,9 +82,9 @@ public sealed class McpToolBuilder(IFunctionsWorkerApplicationBuilder builder, s
     /// <exception cref="System.Text.Json.JsonException">Thrown when the schema string is not valid JSON.</exception>
     public McpToolBuilder WithInputSchema(string jsonSchema)
     {
-        InputSchemaValidator.ValidateAndParse(jsonSchema, nameof(jsonSchema));
+        var schema = new McpInputSchema(jsonSchema);
 
-        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = jsonSchema);
+        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = schema);
 
         return this;
     }
@@ -99,12 +99,9 @@ public sealed class McpToolBuilder(IFunctionsWorkerApplicationBuilder builder, s
     /// <exception cref="ArgumentException">Thrown when the schema does not conform to MCP requirements.</exception>
     public McpToolBuilder WithInputSchema(JsonNode schemaNode)
     {
-        ArgumentNullException.ThrowIfNull(schemaNode, nameof(schemaNode));
+        var schema = new McpInputSchema(schemaNode);
 
-        InputSchemaValidator.Validate(schemaNode, nameof(schemaNode));
-
-        var schemaJson = schemaNode.ToJsonString();
-        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = schemaJson);
+        Builder.Services.Configure<ToolOptions>(Name, o => o.InputSchema = schema);
 
         return this;
     }

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -18,19 +18,23 @@
 
 - Add `WithInputSchema` fluent API for MCP tools (#243)
 
-    Lets users provide an explicit JSON input schema for an MCP tool via `McpToolBuilder.WithInputSchema(string|JsonNode)`. When set, the worker emits the schema and `useWorkerInputSchema=true` on the tool trigger binding, which the host uses instead of generating a schema from tool properties.
+    Lets users provide an explicit JSON input schema for an MCP tool via `McpToolBuilder.WithInputSchema(string|JsonNode)`.
 
     ```csharp
     builder.ConfigureMcpTool("MyTool")
-        .WithInputSchema("""
+        .WithInputSchema(new JsonObject
         {
-            "type": "object",
-            "properties": {
-                "name": { "type": "string", "description": "The user's name" }
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["name"] = new JsonObject
+                {
+                    ["type"] = "string",
+                    ["description"] = "The user's name"
+                }
             },
-            "required": ["name"]
-        }
-        """);
+            ["required"] = new JsonArray("name")
+        });
     ```
 
 - Implement fluent API for building MCP Apps (#226)

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -16,6 +16,23 @@
 
 #### Changes
 
+- Add `WithInputSchema` fluent API for MCP tools (#243)
+
+    Lets users provide an explicit JSON input schema for an MCP tool via `McpToolBuilder.WithInputSchema(string|JsonNode)`. When set, the worker emits the schema and `useWorkerInputSchema=true` on the tool trigger binding, which the host uses instead of generating a schema from tool properties.
+
+    ```csharp
+    builder.ConfigureMcpTool("MyTool")
+        .WithInputSchema("""
+        {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "description": "The user's name" }
+            },
+            "required": ["name"]
+        }
+        """);
+    ```
+
 - Implement fluent API for building MCP Apps (#226)
 
     This feature introduces first-class support for MCP App tools in the MCP extension, enabling tools to be configured as apps with UI views, static assets, and visibility controls. It adds a new configuration model for MCP Apps, emits synthetic resource functions for app views, and includes robust validation and security features for app configuration and static asset serving.

--- a/test/TestAppIsolated/Program.cs
+++ b/test/TestAppIsolated/Program.cs
@@ -49,6 +49,28 @@ builder.ConfigureMcpTool("FluentDefinedTool")
     .WithProperty("city", McpToolPropertyType.String, "The city name.", required: true)
     .WithProperty("zipCode", McpToolPropertyType.String, "The ZIP code.", required: false);
 
+// ── Tool with explicit input schema ─────────────────────────────────────
+
+// Tool whose input schema is explicitly set via WithInputSchema (opt-in)
+builder.ConfigureMcpTool("InputSchemaTool")
+    .WithInputSchema("""
+        {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA"
+                },
+                "units": {
+                    "type": "string",
+                    "description": "The unit system for temperature",
+                    "enum": ["celsius", "fahrenheit"]
+                }
+            },
+            "required": ["location"]
+        }
+        """);
+
 // ── Resource fluent API ─────────────────────────────────────────────────────
 
 // Additional metadata on an attribute-defined resource

--- a/test/TestAppIsolated/Tools/InputSchemaToolFunctions.cs
+++ b/test/TestAppIsolated/Tools/InputSchemaToolFunctions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+using Microsoft.Extensions.Logging;
+
+namespace TestAppIsolated.Tools;
+
+/// <summary>
+/// Tools whose input schema is defined via <c>WithInputSchema</c> in Program.cs.
+/// </summary>
+public class InputSchemaToolFunctions(ILogger<InputSchemaToolFunctions> logger)
+{
+    /// <summary>
+    /// A tool with an explicit input schema set via <c>ConfigureMcpTool().WithInputSchema()</c>.
+    /// The worker emits the schema and signals the host to use it directly.
+    /// </summary>
+    [Function(nameof(InputSchemaTool))]
+    public string InputSchemaTool(
+        [McpToolTrigger(nameof(InputSchemaTool), "A tool with an explicit input schema.")] ToolInvocationContext context)
+    {
+        logger.LogInformation("InputSchemaTool invoked");
+
+        var arguments = context.Arguments;
+        var location = arguments?.TryGetValue("location", out var locVal) == true ? locVal?.ToString() : "(unknown)";
+        var units = arguments?.TryGetValue("units", out var unitsVal) == true ? unitsVal?.ToString() : "celsius";
+        return $"Weather for {location} in {units}";
+    }
+}

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/InputSchemaValidatorTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/InputSchemaValidatorTests.cs
@@ -77,4 +77,44 @@ public class InputSchemaValidatorTests
     {
         Assert.Throws<ArgumentNullException>(() => InputSchemaValidator.Validate(null!, "schema"));
     }
+
+    [Fact]
+    public void ValidateAndParse_PropertiesJsonNull_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            InputSchemaValidator.ValidateAndParse("""{"type":"object","properties":null}""", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_RequiredJsonNull_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            InputSchemaValidator.ValidateAndParse("""{"type":"object","required":null}""", "schema"));
+    }
+
+    // Pins current behavior: element types within "required" are not validated by the worker.
+    // The host silently drops non-string elements in GetRequiredProperties, so these schemas pass
+    // structural validation but the non-string entries will be ignored at runtime.
+    [Theory]
+    [InlineData("""{"type":"object","required":[1,2]}""")]
+    [InlineData("""{"type":"object","required":[true]}""")]
+    [InlineData("""{"type":"object","required":[null]}""")]
+    [InlineData("""{"type":"object","required":[{}]}""")]
+    public void ValidateAndParse_RequiredWithNonStringElements_CurrentlyAllowed(string json)
+    {
+        var node = InputSchemaValidator.ValidateAndParse(json, "schema");
+        Assert.NotNull(node);
+    }
+
+    [Theory]
+    [InlineData("""{"type":null}""")]
+    [InlineData("""{"type":5}""")]
+    [InlineData("""{"type":"Object"}""")]
+    [InlineData("""{"type":["object"]}""")]
+    [InlineData("""{"type":true}""")]
+    [InlineData("""{"type":{}}""")]
+    public void ValidateAndParse_TypeVariants_Throws(string json)
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse(json, "schema"));
+    }
 }

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/InputSchemaValidatorTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/InputSchemaValidatorTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
+
+namespace Worker.Extensions.Mcp.Tests.Configuration;
+
+public class InputSchemaValidatorTests
+{
+    [Fact]
+    public void ValidateAndParse_ValidObjectSchema_ReturnsNode()
+    {
+        var json = """{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}""";
+
+        var node = InputSchemaValidator.ValidateAndParse(json, "schema");
+
+        Assert.NotNull(node);
+        Assert.IsType<JsonObject>(node);
+    }
+
+    [Fact]
+    public void ValidateAndParse_EmptyObjectSchema_Succeeds()
+    {
+        var node = InputSchemaValidator.ValidateAndParse("""{"type":"object"}""", "schema");
+        Assert.NotNull(node);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateAndParse_NullOrWhitespace_Throws(string? value)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => InputSchemaValidator.ValidateAndParse(value!, "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_InvalidJson_ThrowsJsonException()
+    {
+        Assert.ThrowsAny<JsonException>(() => InputSchemaValidator.ValidateAndParse("{not json", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_NotAnObject_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse("[1,2,3]", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_MissingType_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse("""{"properties":{}}""", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_TypeNotObject_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse("""{"type":"string"}""", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_PropertiesNotObject_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse("""{"type":"object","properties":[]}""", "schema"));
+    }
+
+    [Fact]
+    public void ValidateAndParse_RequiredNotArray_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InputSchemaValidator.ValidateAndParse("""{"type":"object","required":"x"}""", "schema"));
+    }
+
+    [Fact]
+    public void Validate_NullNode_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => InputSchemaValidator.Validate(null!, "schema"));
+    }
+}

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/ResolveToolInputSchemaExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/ResolveToolInputSchemaExtensionTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
+using static Worker.Extensions.Mcp.Tests.Helpers.BuilderTestHelper;
+
+namespace Worker.Extensions.Mcp.Tests.Configuration;
+
+public class ResolveToolInputSchemaExtensionTests
+{
+    private const string ValidSchema = """{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}""";
+    private const string ToolBinding = """{"type":"mcpToolTrigger","toolName":"MyTool"}""";
+
+    [Fact]
+    public void ResolveToolInputSchema_NoExplicitSchema_DoesNothing()
+    {
+        var builder = CreateBuilder(CreateToolOptions("MyTool"), CreateResourceOptions(), CreatePromptOptions(), ToolBinding);
+
+        builder.ResolveToolInputSchema();
+
+        var binding = builder.Context.Bindings[0];
+        Assert.Null(binding.InputSchema);
+        Assert.False(binding.UseWorkerInputSchema);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_ExplicitSchema_AppliesSchemaAndFlag()
+    {
+        var toolOptions = CreateToolOptions("MyTool", inputSchema: ValidSchema);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), ToolBinding);
+
+        builder.ResolveToolInputSchema();
+
+        var binding = builder.Context.Bindings[0];
+        Assert.Equal(ValidSchema, binding.InputSchema);
+        Assert.True(binding.UseWorkerInputSchema);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_ExplicitSchema_FlowsThroughBuildToRawBinding()
+    {
+        var toolOptions = CreateToolOptions("MyTool", inputSchema: ValidSchema);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), ToolBinding);
+
+        builder.ResolveToolInputSchema().Build();
+
+        // Build mutates the underlying RawBindings list passed into the function metadata.
+        var raw = builder.Context.Function.RawBindings![0];
+        Assert.Contains("\"inputSchema\":", raw);
+        Assert.Contains("\"useWorkerInputSchema\":true", raw);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_InvalidSchemaInOptions_LogsAndSkips()
+    {
+        // Bypass builder validation by writing directly through the helper.
+        var toolOptions = CreateToolOptions("MyTool", inputSchema: """{"type":"string"}""");
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), ToolBinding);
+
+        builder.ResolveToolInputSchema();
+
+        var binding = builder.Context.Bindings[0];
+        Assert.Null(binding.InputSchema);
+        Assert.False(binding.UseWorkerInputSchema);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_NonToolBinding_Ignored()
+    {
+        var toolOptions = CreateToolOptions("MyTool", inputSchema: ValidSchema);
+        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(),
+            """{"type":"mcpResourceTrigger","uri":"file://x"}""");
+
+        builder.ResolveToolInputSchema();
+
+        var binding = builder.Context.Bindings[0];
+        Assert.Null(binding.InputSchema);
+        Assert.False(binding.UseWorkerInputSchema);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_ReturnsSameBuilder_ForChaining()
+    {
+        var builder = CreateBuilder(ToolBinding);
+
+        var result = builder.ResolveToolInputSchema();
+
+        Assert.Same(builder, result);
+    }
+}

--- a/test/Worker.Extensions.Mcp.Tests/Configuration/ResolveToolInputSchemaExtensionTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Configuration/ResolveToolInputSchemaExtensionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration.Builders.Steps;
 using static Worker.Extensions.Mcp.Tests.Helpers.BuilderTestHelper;
 
@@ -51,20 +52,6 @@ public class ResolveToolInputSchemaExtensionTests
     }
 
     [Fact]
-    public void ResolveToolInputSchema_InvalidSchemaInOptions_LogsAndSkips()
-    {
-        // Bypass builder validation by writing directly through the helper.
-        var toolOptions = CreateToolOptions("MyTool", inputSchema: """{"type":"string"}""");
-        var builder = CreateBuilder(toolOptions, CreateResourceOptions(), CreatePromptOptions(), ToolBinding);
-
-        builder.ResolveToolInputSchema();
-
-        var binding = builder.Context.Bindings[0];
-        Assert.Null(binding.InputSchema);
-        Assert.False(binding.UseWorkerInputSchema);
-    }
-
-    [Fact]
     public void ResolveToolInputSchema_NonToolBinding_Ignored()
     {
         var toolOptions = CreateToolOptions("MyTool", inputSchema: ValidSchema);
@@ -86,5 +73,12 @@ public class ResolveToolInputSchemaExtensionTests
         var result = builder.ResolveToolInputSchema();
 
         Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void ResolveToolInputSchema_NullBuilder_Throws()
+    {
+        McpBindingBuilder? builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder!.ResolveToolInputSchema());
     }
 }

--- a/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
@@ -46,14 +46,15 @@ internal static class BuilderTestHelper
     public static IOptionsMonitor<ToolOptions> CreateToolOptions(
         string? toolName = null,
         List<ToolProperty>? properties = null,
-        Dictionary<string, object>? metadata = null)
+        Dictionary<string, object>? metadata = null,
+        string? inputSchema = null)
     {
         var mock = new Mock<IOptionsMonitor<ToolOptions>>();
         var defaultOptions = new ToolOptions { Properties = [] };
 
         if (toolName is not null)
         {
-            var namedOptions = new ToolOptions { Properties = properties ?? [] };
+            var namedOptions = new ToolOptions { Properties = properties ?? [], InputSchema = inputSchema };
             PopulateMetadata(namedOptions, metadata);
             mock.Setup(o => o.Get(toolName)).Returns(namedOptions);
             mock.Setup(o => o.Get(It.Is<string>(s => s != toolName))).Returns(defaultOptions);

--- a/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
+++ b/test/Worker.Extensions.Mcp.Tests/Helpers/BuilderTestHelper.cs
@@ -1,3 +1,4 @@
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
@@ -54,7 +55,11 @@ internal static class BuilderTestHelper
 
         if (toolName is not null)
         {
-            var namedOptions = new ToolOptions { Properties = properties ?? [], InputSchema = inputSchema };
+            var namedOptions = new ToolOptions
+            {
+                Properties = properties ?? [],
+                InputSchema = inputSchema is null ? null : new McpInputSchema(inputSchema)
+            };
             PopulateMetadata(namedOptions, metadata);
             mock.Setup(o => o.Get(toolName)).Returns(namedOptions);
             mock.Setup(o => o.Get(It.Is<string>(s => s != toolName))).Returns(defaultOptions);

--- a/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
@@ -331,4 +331,22 @@ public class McpToolBuilderTests
         Assert.Single(options.Properties);
         Assert.NotNull(options.InputSchema);
     }
+
+    [Fact]
+    public void WithInputSchema_CalledTwice_LastWriteWins()
+    {
+        var builder = CreateBuilder("tool", out var services);
+        var first = """{"type":"object","properties":{"a":{"type":"string"}}}""";
+        var second = """{"type":"object","properties":{"b":{"type":"integer"}},"required":["b"]}""";
+
+        builder.WithInputSchema(first);
+        builder.WithInputSchema(second);
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
+
+        Assert.NotNull(options.InputSchema);
+        Assert.Contains("\"b\"", options.InputSchema);
+        Assert.DoesNotContain("\"a\"", options.InputSchema);
+    }
 }

--- a/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
@@ -263,7 +263,8 @@ public class McpToolBuilderTests
 
         using var sp = services.BuildServiceProvider();
         var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
-        Assert.Equal(schema, options.InputSchema);
+        Assert.NotNull(options.InputSchema);
+        Assert.Equal(schema, options.InputSchema!.Json);
     }
 
     [Fact]
@@ -277,7 +278,7 @@ public class McpToolBuilderTests
         using var sp = services.BuildServiceProvider();
         var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
         Assert.NotNull(options.InputSchema);
-        Assert.Contains("\"type\":\"object\"", options.InputSchema);
+        Assert.Contains("\"type\":\"object\"", options.InputSchema!.Json);
     }
 
     [Theory]
@@ -346,7 +347,7 @@ public class McpToolBuilderTests
         var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
 
         Assert.NotNull(options.InputSchema);
-        Assert.Contains("\"b\"", options.InputSchema);
-        Assert.DoesNotContain("\"a\"", options.InputSchema);
+        Assert.Contains("\"b\"", options.InputSchema!.Json);
+        Assert.DoesNotContain("\"a\"", options.InputSchema!.Json);
     }
 }

--- a/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpToolBuilderTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
@@ -249,5 +251,84 @@ public class McpToolBuilderTests
             new KeyValuePair<string, object?>("key2", "value2"));
 
         Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void WithInputSchema_String_StoresSchemaInOptions()
+    {
+        var builder = CreateBuilder("tool", out var services);
+        var schema = """{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]}""";
+
+        builder.WithInputSchema(schema);
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
+        Assert.Equal(schema, options.InputSchema);
+    }
+
+    [Fact]
+    public void WithInputSchema_JsonNode_StoresSchemaInOptions()
+    {
+        var builder = CreateBuilder("tool", out var services);
+        var node = JsonNode.Parse("""{"type":"object"}""")!;
+
+        builder.WithInputSchema(node);
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
+        Assert.NotNull(options.InputSchema);
+        Assert.Contains("\"type\":\"object\"", options.InputSchema);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void WithInputSchema_String_NullOrEmpty_Throws(string? value)
+    {
+        var builder = CreateBuilder("tool", out _);
+        Assert.ThrowsAny<ArgumentException>(() => builder.WithInputSchema(value!));
+    }
+
+    [Fact]
+    public void WithInputSchema_String_InvalidJson_ThrowsJsonException()
+    {
+        var builder = CreateBuilder("tool", out _);
+        Assert.ThrowsAny<JsonException>(() => builder.WithInputSchema("{not json"));
+    }
+
+    [Fact]
+    public void WithInputSchema_String_NotObjectSchema_Throws()
+    {
+        var builder = CreateBuilder("tool", out _);
+        Assert.Throws<ArgumentException>(() => builder.WithInputSchema("""{"type":"string"}"""));
+    }
+
+    [Fact]
+    public void WithInputSchema_JsonNode_Null_Throws()
+    {
+        var builder = CreateBuilder("tool", out _);
+        Assert.Throws<ArgumentNullException>(() => builder.WithInputSchema((JsonNode)null!));
+    }
+
+    [Fact]
+    public void WithInputSchema_String_ReturnsSameBuilder_ForChaining()
+    {
+        var builder = CreateBuilder("tool", out _);
+        var result = builder.WithInputSchema("""{"type":"object"}""");
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void WithInputSchema_CombinedWithWithProperty_BothPersist()
+    {
+        var builder = CreateBuilder("tool", out var services);
+
+        builder.WithProperty("p", McpToolPropertyType.String, "desc")
+               .WithInputSchema("""{"type":"object"}""");
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptionsMonitor<ToolOptions>>().Get("tool");
+        Assert.Single(options.Properties);
+        Assert.NotNull(options.InputSchema);
     }
 }

--- a/test/Worker.Mcp.E2ETests/ToolTests/CallToolTests.cs
+++ b/test/Worker.Mcp.E2ETests/ToolTests/CallToolTests.cs
@@ -302,6 +302,30 @@ public class CallToolTests(DefaultProjectFixture fixture, ITestOutputHelper test
         Assert.Contains("MinimalApp", response);
     }
 
+    // ── Input schema tools ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InputSchemaTool_WithAllArguments_ReturnsExpectedResponse()
+    {
+        var request = CallToolHelper.CreateToolCallRequest(1, "InputSchemaTool", new { location = "Seattle, WA", units = "fahrenheit" });
+        var response = await CallToolHelper.MakeToolCallRequest(AppRootEndpoint, request, TestOutputHelper);
+
+        Assert.NotNull(response);
+        Assert.Contains("Seattle, WA", response);
+        Assert.Contains("fahrenheit", response);
+    }
+
+    [Fact]
+    public async Task InputSchemaTool_WithRequiredOnly_ReturnsDefaultUnits()
+    {
+        var request = CallToolHelper.CreateToolCallRequest(1, "InputSchemaTool", new { location = "Portland, OR" });
+        var response = await CallToolHelper.MakeToolCallRequest(AppRootEndpoint, request, TestOutputHelper);
+
+        Assert.NotNull(response);
+        Assert.Contains("Portland, OR", response);
+        Assert.Contains("celsius", response);
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/test/Worker.Mcp.E2ETests/ToolTests/CallToolTests.cs
+++ b/test/Worker.Mcp.E2ETests/ToolTests/CallToolTests.cs
@@ -326,6 +326,16 @@ public class CallToolTests(DefaultProjectFixture fixture, ITestOutputHelper test
         Assert.Contains("celsius", response);
     }
 
+    [Fact]
+    public async Task InputSchemaTool_WithoutRequiredLocation_ReturnsError()
+    {
+        var request = CallToolHelper.CreateToolCallRequest(1, "InputSchemaTool", new { units = "fahrenheit" });
+        var response = await CallToolHelper.MakeToolCallRequest(AppRootEndpoint, request, TestOutputHelper);
+
+        Assert.Contains("error", response);
+        Assert.Contains("location", response);
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/test/Worker.Mcp.E2ETests/ToolTests/ListToolTests.cs
+++ b/test/Worker.Mcp.E2ETests/ToolTests/ListToolTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Worker.Mcp.E2ETests.Fixtures;
 using Microsoft.Azure.Functions.Worker.Mcp.E2ETests.ProtocolTests;
@@ -20,7 +21,7 @@ public class ListToolTests(DefaultProjectFixture fixture, ITestOutputHelper test
         var client = await Fixture.CreateClientAsync(mode);
         var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.True(tools.Count >= 19, $"Expected at least 19 tools but found {tools.Count}");
+        Assert.True(tools.Count >= 20, $"Expected at least 20 tools but found {tools.Count}");
     }
 
     [Theory]
@@ -155,5 +156,59 @@ public class ListToolTests(DefaultProjectFixture fixture, ITestOutputHelper test
         Assert.Equal("1.0", ((JsonNode)tool.ProtocolTool.Meta["imageVersion"]!).GetValue<string>());
         Assert.True(tool.ProtocolTool.Meta.ContainsKey("source"), "Tool should contain 'source' metadata");
         Assert.Equal("builder", ((JsonNode)tool.ProtocolTool.Meta["source"]!).GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData(HttpTransportMode.Sse)]
+    [InlineData(HttpTransportMode.AutoDetect)]
+    [InlineData(HttpTransportMode.StreamableHttp)]
+    public async Task ListTools_ContainsInputSchemaTool(HttpTransportMode mode)
+    {
+        var client = await Fixture.CreateClientAsync(mode);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains(tools, t => t.Name == "InputSchemaTool");
+    }
+
+    [Theory]
+    [InlineData(HttpTransportMode.Sse)]
+    [InlineData(HttpTransportMode.AutoDetect)]
+    [InlineData(HttpTransportMode.StreamableHttp)]
+    public async Task ListTools_InputSchemaTool_HasExplicitInputSchema(HttpTransportMode mode)
+    {
+        var client = await Fixture.CreateClientAsync(mode);
+        var tools = await client.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var tool = tools.FirstOrDefault(t => t.Name == "InputSchemaTool");
+        Assert.NotNull(tool);
+
+        var inputSchema = tool.ProtocolTool.InputSchema;
+        Assert.Equal(JsonValueKind.Object, inputSchema.ValueKind);
+
+        // Root must be "type": "object"
+        Assert.True(inputSchema.TryGetProperty("type", out var typeProp));
+        Assert.Equal("object", typeProp.GetString());
+
+        // "properties" must contain "location" and "units"
+        Assert.True(inputSchema.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("location", out var locationProp));
+        Assert.Equal("string", locationProp.GetProperty("type").GetString());
+        Assert.Equal("The city and state, e.g. San Francisco, CA", locationProp.GetProperty("description").GetString());
+
+        Assert.True(properties.TryGetProperty("units", out var unitsProp));
+        Assert.Equal("string", unitsProp.GetProperty("type").GetString());
+        Assert.Equal("The unit system for temperature", unitsProp.GetProperty("description").GetString());
+
+        // "units" should have an enum constraint
+        Assert.True(unitsProp.TryGetProperty("enum", out var enumProp));
+        var enumValues = enumProp.EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains("celsius", enumValues);
+        Assert.Contains("fahrenheit", enumValues);
+
+        // "required" must contain only "location"
+        Assert.True(inputSchema.TryGetProperty("required", out var required));
+        var requiredValues = required.EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains("location", requiredValues);
+        Assert.DoesNotContain("units", requiredValues);
     }
 }


### PR DESCRIPTION
Lets users provide an explicit JSON input schema for an MCP tool via McpToolBuilder.WithInputSchema(string|JsonNode). When set, the worker emits the schema and useWorkerInputSchema=true on the tool trigger binding, which the host already understands via McpToolTriggerAttribute.

Schema validation mirrors host McpInputSchemaJsonUtilities.IsValidMcpToolSchema so a schema that the worker accepts will not be rejected by the host:
- root must be a JSON object
- type="object" required at root
- properties must be a JSON object when present
- required must be a JSON array when present

The new ResolveToolInputSchema pipeline step is wired after PatchPropertyBindings (no behavior change to the existing properties path). When no explicit schema is configured, the step is a no-op and the host continues to generate a schema from toolProperties.

Reflection-based / POCO-based auto schema generation is intentionally out of scope for this PR — it would risk drift between the worker schema and the actual host binder semantics.

Tools only. Prompts and resources don't yet have host-side input-schema support.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #167 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
