### PR TITLE
Enforce required prompt arguments at protocol boundary

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/ToolInputSchema/ToolInputSchema.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/ToolInputSchema/ToolInputSchema.cs
@@ -33,7 +33,7 @@ internal abstract class ToolInputSchema
         {
             if (args == null
                 || !args.TryGetValue(propertyName, out var value)
-                || IsValueNullOrUndefined(value))
+                || value.IsNullOrUndefined())
             {
                 missing.Add(propertyName);
             }
@@ -57,21 +57,6 @@ internal abstract class ToolInputSchema
     /// </summary>
     /// <returns>A collection of required property names.</returns>
     protected abstract IReadOnlyCollection<string> GetRequiredProperties();
-
-    /// <summary>
-    /// Checks if a JSON element represents a null or undefined value.
-    /// </summary>
-    /// <param name="value">The JSON element to check.</param>
-    /// <returns>True if the value is null or undefined; otherwise false.</returns>
-    protected static bool IsValueNullOrUndefined(JsonElement value)
-    {
-        return value.ValueKind switch
-        {
-            JsonValueKind.Null => true,
-            JsonValueKind.Undefined => true,
-            _ => false
-        };
-    }
 
     /// <summary>
     /// Creates a validation exception for missing required properties.

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptListener.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptListener.cs
@@ -88,7 +88,7 @@ internal sealed class McpPromptListener(
 
             if (provided is null
                 || !provided.TryGetValue(declared.Name, out var value)
-                || IsValueNullOrUndefined(value))
+                || value.IsNullOrUndefined())
             {
                 (missing ??= []).Add(declared.Name);
             }
@@ -101,12 +101,5 @@ internal sealed class McpPromptListener(
                 McpErrorCode.InvalidParams);
         }
     }
-
-    private static bool IsValueNullOrUndefined(JsonElement value) => value.ValueKind switch
-    {
-        JsonValueKind.Null => true,
-        JsonValueKind.Undefined => true,
-        _ => false,
-    };
 }
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptListener.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/McpPromptListener.cs
@@ -3,8 +3,10 @@
 
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using System.Text.Json;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp;
 
@@ -44,6 +46,11 @@ internal sealed class McpPromptListener(
 
     public async Task<GetPromptResult> GetAsync(RequestContext<GetPromptRequestParams> getPromptRequest, CancellationToken cancellationToken)
     {
+        // Enforce required prompt arguments at the protocol boundary so every
+        // worker model (TypeScript / Python / Java / .NET in-proc / .NET isolated)
+        // gets the same guarantee the tool path provides via ToolInputSchema.Validate.
+        ValidateRequiredArguments(getPromptRequest.Params);
+
         var execution = new GetPromptExecutionContext(getPromptRequest);
 
         var input = new TriggeredFunctionData
@@ -61,4 +68,45 @@ internal sealed class McpPromptListener(
         var promptResult = await execution.ResultTask;
         return promptResult;
     }
+
+    private void ValidateRequiredArguments(GetPromptRequestParams? requestParams)
+    {
+        if (Arguments is null || Arguments.Count == 0)
+        {
+            return;
+        }
+
+        var provided = requestParams?.Arguments;
+        List<string>? missing = null;
+
+        foreach (var declared in Arguments)
+        {
+            if (declared.Required != true)
+            {
+                continue;
+            }
+
+            if (provided is null
+                || !provided.TryGetValue(declared.Name, out var value)
+                || IsValueNullOrUndefined(value))
+            {
+                (missing ??= []).Add(declared.Name);
+            }
+        }
+
+        if (missing is { Count: > 0 })
+        {
+            throw new McpProtocolException(
+                $"One or more required prompt arguments are missing values. Please provide: {string.Join(", ", missing)}",
+                McpErrorCode.InvalidParams);
+        }
+    }
+
+    private static bool IsValueNullOrUndefined(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Null => true,
+        JsonValueKind.Undefined => true,
+        _ => false,
+    };
 }
+

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Utilities/JsonElementExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Utilities/JsonElementExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Microsoft.Azure.Functions.Extensions.Mcp;
+
+internal static class JsonElementExtensions
+{
+    /// <summary>
+    /// Checks if a JSON element represents a null or undefined value.
+    /// </summary>
+    /// <param name="value">The JSON element to check.</param>
+    /// <returns>True if the value is null or undefined; otherwise false.</returns>
+    public static bool IsNullOrUndefined(this JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Null => true,
+        JsonValueKind.Undefined => true,
+        _ => false,
+    };
+}

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Extensions <version>
 
-- <entry>
+- Enforce required prompt arguments at the protocol boundary in `McpPromptListener` so all worker models (TypeScript / Python / Java / .NET) get the same validation that tools already have via `ToolInputSchema.Validate`. Previously, required prompt argument validation only ran for .NET parameters annotated with `[McpPromptArgument(IsRequired = true)]`. (#TBD)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0-preview.1
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Extensions <version>
 
-- Enforce required prompt arguments at the protocol boundary in `McpPromptListener` so all worker models (TypeScript / Python / Java / .NET) get the same validation that tools already have via `ToolInputSchema.Validate`. Previously, required prompt argument validation only ran for .NET parameters annotated with `[McpPromptArgument(IsRequired = true)]`. (#TBD)
+- Validate required prompt arguments (#244)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0-preview.1
 

--- a/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
@@ -260,6 +260,7 @@ public class McpPromptListenerTests
         var ex = await Assert.ThrowsAsync<McpProtocolException>(
             () => listener.GetAsync(CreateRequest("code_review"), CancellationToken.None));
 
+        Assert.Equal(McpErrorCode.InvalidParams, ex.ErrorCode);
         Assert.Contains("code", ex.Message);
         executor.VerifyNoOtherCalls();
     }
@@ -284,6 +285,7 @@ public class McpPromptListenerTests
         var ex = await Assert.ThrowsAsync<McpProtocolException>(
             () => listener.GetAsync(CreateRequest("code_review", args), CancellationToken.None));
 
+        Assert.Equal(McpErrorCode.InvalidParams, ex.ErrorCode);
         Assert.Contains("code", ex.Message);
         executor.VerifyNoOtherCalls();
     }
@@ -310,6 +312,7 @@ public class McpPromptListenerTests
         var ex = await Assert.ThrowsAsync<McpProtocolException>(
             () => listener.GetAsync(CreateRequest("p"), CancellationToken.None));
 
+        Assert.Equal(McpErrorCode.InvalidParams, ex.ErrorCode);
         Assert.Contains("a", ex.Message);
         Assert.Contains("b", ex.Message);
         Assert.DoesNotContain("c", ex.Message);

--- a/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
@@ -2,24 +2,30 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.WebJobs.Host.Executors;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Moq;
+using System.Text.Json;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
 
 public class McpPromptListenerTests
 {
-    private static RequestContext<GetPromptRequestParams> CreateRequest(string name = "TestPrompt")
+    private static RequestContext<GetPromptRequestParams> CreateRequest(
+        string name = "TestPrompt",
+        IReadOnlyDictionary<string, JsonElement>? arguments = null)
     {
         var server = new Mock<McpServer>().Object;
-        var parameters = new GetPromptRequestParams { Name = name };
+        var parameters = new GetPromptRequestParams { Name = name, Arguments = arguments };
 
         return new RequestContext<GetPromptRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.PromptsGet })
         {
             Params = parameters
         };
     }
+
+    private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement;
 
     [Fact]
     public void Constructor_SetsProperties()
@@ -232,5 +238,166 @@ public class McpPromptListenerTests
             null,
             null,
             new Dictionary<string, object?>());
+    }
+
+    // ── Required-argument validation ─────────────────────────────────────
+
+    [Fact]
+    public async Task GetAsync_RequiredArgumentMissing_ThrowsMcpProtocolException()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "code_review",
+            null,
+            null,
+            [new() { Name = "code", Required = true }],
+            null,
+            new Dictionary<string, object?>());
+
+        var ex = await Assert.ThrowsAsync<McpProtocolException>(
+            () => listener.GetAsync(CreateRequest("code_review"), CancellationToken.None));
+
+        Assert.Contains("code", ex.Message);
+        executor.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetAsync_RequiredArgumentNull_ThrowsMcpProtocolException()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "code_review",
+            null,
+            null,
+            [new() { Name = "code", Required = true }],
+            null,
+            new Dictionary<string, object?>());
+
+        var args = new Dictionary<string, JsonElement> { ["code"] = Json("null") };
+
+        var ex = await Assert.ThrowsAsync<McpProtocolException>(
+            () => listener.GetAsync(CreateRequest("code_review", args), CancellationToken.None));
+
+        Assert.Contains("code", ex.Message);
+        executor.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetAsync_MultipleRequiredArgumentsMissing_ListsAllInMessage()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "p",
+            null,
+            null,
+            [
+                new() { Name = "a", Required = true },
+                new() { Name = "b", Required = true },
+                new() { Name = "c", Required = false },
+            ],
+            null,
+            new Dictionary<string, object?>());
+
+        var ex = await Assert.ThrowsAsync<McpProtocolException>(
+            () => listener.GetAsync(CreateRequest("p"), CancellationToken.None));
+
+        Assert.Contains("a", ex.Message);
+        Assert.Contains("b", ex.Message);
+        Assert.DoesNotContain("c", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetAsync_OptionalArgumentMissing_DoesNotThrow()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>();
+        executor.Setup(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+            .Callback<TriggeredFunctionData, CancellationToken>((data, _) =>
+            {
+                var execCtx = (GetPromptExecutionContext)data.TriggerValue;
+                execCtx.SetResult(new GetPromptResult { Messages = [] });
+            })
+            .ReturnsAsync(new FunctionResult(true));
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "p",
+            null,
+            null,
+            [new() { Name = "optional_arg", Required = false }],
+            null,
+            new Dictionary<string, object?>());
+
+        var result = await listener.GetAsync(CreateRequest("p"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        executor.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetAsync_RequiredArgumentProvided_DoesNotThrow()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>();
+        executor.Setup(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+            .Callback<TriggeredFunctionData, CancellationToken>((data, _) =>
+            {
+                var execCtx = (GetPromptExecutionContext)data.TriggerValue;
+                execCtx.SetResult(new GetPromptResult { Messages = [] });
+            })
+            .ReturnsAsync(new FunctionResult(true));
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "code_review",
+            null,
+            null,
+            [new() { Name = "code", Required = true }],
+            null,
+            new Dictionary<string, object?>());
+
+        var args = new Dictionary<string, JsonElement> { ["code"] = Json("\"hello\"") };
+
+        var result = await listener.GetAsync(CreateRequest("code_review", args), CancellationToken.None);
+
+        Assert.NotNull(result);
+        executor.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetAsync_NoDeclaredArguments_DoesNotValidate()
+    {
+        var executor = new Mock<ITriggeredFunctionExecutor>();
+        executor.Setup(e => e.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+            .Callback<TriggeredFunctionData, CancellationToken>((data, _) =>
+            {
+                var execCtx = (GetPromptExecutionContext)data.TriggerValue;
+                execCtx.SetResult(new GetPromptResult { Messages = [] });
+            })
+            .ReturnsAsync(new FunctionResult(true));
+
+        var listener = new McpPromptListener(
+            executor.Object,
+            "MyFunction",
+            "p",
+            null,
+            null,
+            arguments: null,
+            null,
+            new Dictionary<string, object?>());
+
+        var result = await listener.GetAsync(CreateRequest("p"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        executor.VerifyAll();
     }
 }

--- a/test/Worker.Mcp.E2ETests/PromptTests/GetPromptTests.cs
+++ b/test/Worker.Mcp.E2ETests/PromptTests/GetPromptTests.cs
@@ -180,6 +180,7 @@ public class GetPromptTests(DefaultProjectFixture fixture, ITestOutputHelper tes
 
         var result = await client.GetPromptAsync(
             "fluent_prompt",
+            arguments: new Dictionary<string, object?> { ["query"] = "test" },
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);


### PR DESCRIPTION
McpPromptListener.GetAsync now validates required arguments declared on the prompt against the inbound GetPromptRequestParams.Arguments before invoking the function, mirroring the tool path's protocol-level validation in McpToolListener (ToolInputSchema.Validate).

Previously, required prompt arguments were only enforced via PromptArgumentInputBinding.BindAsync, which runs only when a worker parameter is decorated with [McpPromptArgument(IsRequired = true)]. That works for the .NET worker but provides no enforcement for TypeScript / Python / Java workers, which surface 'required' on prompts/list as advisory metadata only.

The thrown McpProtocolException uses InvalidParams to match the tool-side error semantics, and lists all missing required arguments in a single message.

