### PR TITLE
Fix MCP App FileViewSource path resolution on Azure

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptionsValidator.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Configuration/ToolOptionsValidator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.McpApp;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Configuration;
@@ -28,6 +29,16 @@ internal sealed class ToolOptionsValidator : IValidateOptions<ToolOptions>
             return ValidateOptionsResult.Fail(
                 $"MCP App tool '{name}' has a view with no source configured. " +
                 $"Call WithView() with a McpViewSource or file path.");
+        }
+
+        if (appOptions.View.Source is FileViewSource fileSource
+            && !File.Exists(fileSource.ResolvedPath))
+        {
+            return ValidateOptionsResult.Fail(
+                $"MCP App tool '{name}' has a file view source pointing to '{fileSource.Path}', " +
+                $"which was not found at '{fileSource.ResolvedPath}'. Relative paths are resolved " +
+                $"against the application base directory (AppContext.BaseDirectory). Ensure the file " +
+                $"is copied to the output/publish directory (e.g., set CopyToOutputDirectory in your csproj).");
         }
 
         if (appOptions.StaticAssetsDirectory is not null

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/DependencyInjection/IMcpAppBuilder.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/DependencyInjection/IMcpAppBuilder.cs
@@ -19,6 +19,10 @@ public interface IMcpAppBuilder
     /// <summary>
     /// Sets the view backed by a file.
     /// Shorthand for <c>WithView(McpViewSource.FromFile(filePath))</c>.
+    /// Relative paths are resolved against the application's base directory
+    /// (publish/output directory). Ensure the file is copied to the output directory
+    /// (e.g., <c>&lt;Content Include="..." CopyToOutputDirectory="PreserveNewest" /&gt;</c>)
+    /// so it is present both locally and when deployed.
     /// </summary>
     IMcpViewBuilder WithView(string filePath);
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/FileViewSource.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/FileViewSource.cs
@@ -6,9 +6,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.McpApp;
 /// <summary>
 /// A view source backed by a file on disk.
 /// </summary>
-/// <param name="Path">The path to the HTML file.</param>
+/// <param name="Path">
+/// The path to the HTML file. If relative, it is resolved against the
+/// application's base directory (<see cref="AppContext.BaseDirectory"/>)
+/// rather than the current working directory. This avoids path resolution
+/// issues in hosting environments (e.g., Azure Functions placeholder /
+/// specialization) where the process working directory does not match the
+/// deployed app's directory.
+/// </param>
 public sealed record FileViewSource(string Path) : McpViewSource
 {
+    /// <summary>
+    /// Gets the absolute path used to read the file. Relative paths are resolved
+    /// against <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    public string ResolvedPath => System.IO.Path.IsPathRooted(Path)
+        ? Path
+        : System.IO.Path.Combine(AppContext.BaseDirectory, Path);
+
     public override Task<string> GetContentAsync(CancellationToken cancellationToken)
-        => File.ReadAllTextAsync(Path, cancellationToken);
+        => File.ReadAllTextAsync(ResolvedPath, cancellationToken);
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/McpViewSource.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/McpApp/McpViewSource.cs
@@ -23,7 +23,11 @@ public abstract record McpViewSource
     /// Creates a view source backed by a file on disk.
     /// </summary>
     /// <param name="path">
-    /// The path to the HTML file, relative to the application root or absolute.
+    /// The path to the HTML file. If relative, it is resolved against the application's
+    /// base directory (<see cref="AppContext.BaseDirectory"/>) — i.e., the publish/output
+    /// directory — not the current working directory. Ensure the file is copied to the
+    /// output directory (e.g., <c>&lt;Content Include="..." CopyToOutputDirectory="PreserveNewest" /&gt;</c>
+    /// in your csproj) so it is present when running locally and when deployed.
     /// </param>
     public static McpViewSource FromFile(string path)
     {

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -20,6 +20,7 @@
 #### Bug Fixes
 
 - Fixed `DateTime` tool parameters failing to bind when the JSON input contains an ISO 8601 date string. The `DictionaryStringObjectJsonConverter` was deserializing date strings as `DateTimeOffset`, which had no conversion path to `DateTime`. Added explicit `DateTimeOffset` ↔ `DateTime` conversions in `McpInputConversionHelper`.
+- Fixed MCP App `WithView(filePath)` / `McpViewSource.FromFile` failing in Azure with `DirectoryNotFoundException` (e.g., `/tmp/functions/standby/wwwroot/...`). Relative paths were resolved against `Environment.CurrentDirectory`, which on Linux Functions points to the placeholder/standby directory and is not updated after specialization. Relative paths are now resolved against `AppContext.BaseDirectory` (the deployed app's directory). `ToolOptionsValidator` now also fails fast at startup if the resolved file does not exist. Ensure view files are copied to the output directory (e.g., `<Content Include="..." CopyToOutputDirectory="PreserveNewest" />`).
 
 #### Changes
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -20,7 +20,7 @@
 #### Bug Fixes
 
 - Fixed `DateTime` tool parameters failing to bind when the JSON input contains an ISO 8601 date string. The `DictionaryStringObjectJsonConverter` was deserializing date strings as `DateTimeOffset`, which had no conversion path to `DateTime`. Added explicit `DateTimeOffset` ↔ `DateTime` conversions in `McpInputConversionHelper`.
-- Fixed MCP App `WithView(filePath)` / `McpViewSource.FromFile` failing in Azure with `DirectoryNotFoundException` (e.g., `/tmp/functions/standby/wwwroot/...`). Relative paths were resolved against `Environment.CurrentDirectory`, which on Linux Functions points to the placeholder/standby directory and is not updated after specialization. Relative paths are now resolved against `AppContext.BaseDirectory` (the deployed app's directory). `ToolOptionsValidator` now also fails fast at startup if the resolved file does not exist. Ensure view files are copied to the output directory (e.g., `<Content Include="..." CopyToOutputDirectory="PreserveNewest" />`).
+- Fixed MCP App `WithView(filePath)` failing on Azure with `DirectoryNotFoundException` by resolving relative paths against `AppContext.BaseDirectory` instead of the process working directory.
 
 #### Changes
 

--- a/test/Worker.Extensions.Mcp.Tests/ToolOptionsValidatorTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/ToolOptionsValidatorTests.cs
@@ -55,6 +55,34 @@ public class ToolOptionsValidatorTests
     [Fact]
     public void Validate_ViewWithFileSource_ReturnsSuccess()
     {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"mcp-view-{Guid.NewGuid():N}.html");
+        File.WriteAllText(tempFile, "<html></html>");
+        try
+        {
+            var options = new ToolOptions
+            {
+                Properties = [],
+                AppOptions = new AppOptions()
+            };
+            options.AppOptions.View = new ViewOptions
+            {
+                Source = McpViewSource.FromFile(tempFile)
+            };
+
+            var result = _validator.Validate("myTool", options);
+
+            Assert.True(result.Succeeded);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Validate_ViewWithFileSource_MissingFile_ReturnsFail()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"mcp-missing-{Guid.NewGuid():N}.html");
         var options = new ToolOptions
         {
             Properties = [],
@@ -62,12 +90,14 @@ public class ToolOptionsValidatorTests
         };
         options.AppOptions.View = new ViewOptions
         {
-            Source = McpViewSource.FromFile("ui/app.html")
+            Source = McpViewSource.FromFile(missing)
         };
 
         var result = _validator.Validate("myTool", options);
 
-        Assert.True(result.Succeeded);
+        Assert.True(result.Failed);
+        Assert.Contains("not found", result.FailureMessage);
+        Assert.Contains("CopyToOutputDirectory", result.FailureMessage);
     }
 
     [Fact]
@@ -91,21 +121,30 @@ public class ToolOptionsValidatorTests
     [Fact]
     public void Validate_EmptyStaticAssetsDirectory_ReturnsFail()
     {
-        var options = new ToolOptions
+        var tempFile = Path.Combine(Path.GetTempPath(), $"mcp-view-{Guid.NewGuid():N}.html");
+        File.WriteAllText(tempFile, "<html></html>");
+        try
         {
-            Properties = [],
-            AppOptions = new AppOptions()
-        };
-        options.AppOptions.View = new ViewOptions
+            var options = new ToolOptions
+            {
+                Properties = [],
+                AppOptions = new AppOptions()
+            };
+            options.AppOptions.View = new ViewOptions
+            {
+                Source = McpViewSource.FromFile(tempFile)
+            };
+            options.AppOptions.StaticAssetsDirectory = "   ";
+
+            var result = _validator.Validate("myTool", options);
+
+            Assert.True(result.Failed);
+            Assert.Contains("empty StaticAssetsDirectory", result.FailureMessage);
+        }
+        finally
         {
-            Source = McpViewSource.FromFile("ok.html")
-        };
-        options.AppOptions.StaticAssetsDirectory = "   ";
-
-        var result = _validator.Validate("myTool", options);
-
-        Assert.True(result.Failed);
-        Assert.Contains("empty StaticAssetsDirectory", result.FailureMessage);
+            File.Delete(tempFile);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

MCP App tools configured with `WithView("relative/path.html")` (or `McpViewSource.FromFile`) work locally but fail on Azure Functions (Linux) at invocation time with:

```
System.IO.DirectoryNotFoundException: Could not find a part of the path '/tmp/functions/standby/wwwroot/app/dist/index.html'.
   at System.IO.File.InternalReadAllTextAsync(...)
   at FunctionsMcpAppMiddleware.Invoke(...)
```

Root cause: `FileViewSource` passed the user-provided path straight to `File.ReadAllTextAsync`, which resolves relative paths against `Environment.CurrentDirectory`. On Linux Functions the process working directory is the placeholder/standby location (`/tmp/functions/standby/wwwroot`) and is **not** updated after specialization, so the file is looked up in the wrong place. Locally `cwd == app dir`, so the bug was masked.

**Fix:** resolve relative paths in `FileViewSource` against `AppContext.BaseDirectory` (the deployed app's directory). Absolute paths pass through unchanged. `ToolOptionsValidator` now also fails fast at startup if the resolved file is missing, so users get a clear error instead of a runtime `DirectoryNotFoundException` on first invocation. Doc comments on `WithView(string)` / `McpViewSource.FromFile` now call out the requirement to copy the file to the output directory (e.g., `<Content Include="..." CopyToOutputDirectory="PreserveNewest" />`).

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [x] Otherwise: Documentation issue linked to PR — XML doc comments updated on the public API surface
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Behavior change worth noting: previously a user could rely on cwd-relative paths working locally even when the file wasn't in the build output. After this fix, the file must exist under `AppContext.BaseDirectory` both locally and on Azure (which is the same requirement as deployment). The new validator failure surfaces this clearly at startup. All 500 existing worker tests pass.