### PR TITLE
Release prep for worker ext v1.5.0

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <VersionPrefix>1.5.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -6,7 +6,7 @@
 
 ### Microsoft.Azure.Functions.Extensions <version>
 
-- <entry>
+- Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -4,19 +4,11 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Extensions 1.5.0
+### Microsoft.Azure.Functions.Extensions <version>
 
-#### Breaking Changes
+- <entry>
 
-- `McpInputSchemaJsonUtilities` is now `internal` (was `public`). It was never intended as a public API. (#245)
-
-#### Changes
-
-- Validate required prompt arguments (#244)
-- Added output schema support on the tool trigger (#245)
-- Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
-
-### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0-preview.1
+### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.0
 
 #### Bug Fixes
 


### PR DESCRIPTION
Promotes `Microsoft.Azure.Functions.Worker.Extensions.Mcp` from `1.5.0-preview.1` to the stable `1.5.0` release.

## Changes

- `src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props`: drop `VersionSuffix` (`preview.1`), keep `VersionPrefix` at `1.5.0`.
- `src/release_notes.md`:
  - Update worker section heading to `1.5.0` (was `1.5.0-preview.1`).
  - Reset host extension section to the `<version>` placeholder now that `1.5.0` shipped.