### PR TITLE
test: failing repro for #260 (array of complex tool properties)

### DIFF
--- a/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
@@ -173,6 +173,45 @@ public class McpInputConversionHelperTests
         Assert.Equal(expected, result);
     }
 
+    [Fact]
+    public void TryConvertToTargetType_ArrayOfComplexType_PreservesElementValues()
+    {
+        var input = new List<object?>
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Widget",
+                ["Quantity"] = 3,
+            },
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Gadget",
+                ["Quantity"] = 7,
+            },
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(Item[]), out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        var items = Assert.IsType<Item[]>(result);
+        Assert.Equal(2, items.Length);
+
+        Assert.NotNull(items[0]);
+        Assert.Equal("Widget", items[0]!.Name);
+        Assert.Equal(3, items[0]!.Quantity);
+
+        Assert.NotNull(items[1]);
+        Assert.Equal("Gadget", items[1]!.Name);
+        Assert.Equal(7, items[1]!.Quantity);
+    }
+
+    private class Item
+    {
+        public string? Name { get; set; }
+        public int Quantity { get; set; }
+    }
+
     [TypeConverter(typeof(TestPocoConverter))]
     private class TestPoco
     {


### PR DESCRIPTION
Adds a failing unit test that reproduces #260: in the worker extension, a tool property typed as an array of a complex type comes back with all elements `null` after argument conversion.

This PR is intentionally **test-only** and **failing**, opened as a draft for review of the repro shape before the fix lands.

## Repro

`McpInputConversionHelperTests.TryConvertToTargetType_ArrayOfComplexType_PreservesElementValues` builds the same shape the dictionary converter produces for an MCP tool argument (a `List<object?>` of `Dictionary<string, object>` entries) and asks `TryConvertArgumentToTargetType` to convert it to `Item[]`. The conversion reports success and returns an `Item[]` of the right length, but every element is `null`.

## Failure

```
Assert.NotNull() Failure: Value is null
  at McpInputConversionHelperTests.TryConvertToTargetType_ArrayOfComplexType_PreservesElementValues()
```

## Root cause (per investigation in #260)

`ConvertElementIfNeeded` calls `TryConvertArgumentToTargetType(dict, POCO)`, which falls through every branch in `ConvertArgumentToTargetType` and returns `null`, so each element of the resulting array is `null`.

No production code is changed in this PR.

Refs: #260