### PR TITLE
fix: support array, list, and nested POCO tool properties (#260)

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/McpInputConversionHelper.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/McpInputConversionHelper.cs
@@ -5,6 +5,8 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Globalization;
+using System.Reflection;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp.Reflection;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Mcp.Converters;
 
@@ -12,6 +14,7 @@ internal static class McpInputConversionHelper
 {
     private static readonly ConcurrentDictionary<Type, Func<int, IList>> _listFactoryCache = new();
     private static readonly ConcurrentDictionary<Type, Type> _elementTypeCache = new();
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _writablePropertyCache = new();
 
     public static bool TryConvertArgumentToTargetType(object? value, Type targetType, out object? result)
     {
@@ -76,6 +79,11 @@ internal static class McpInputConversionHelper
             return ConvertToCollection(inputCollection, targetType);
         }
 
+        if (targetType.IsPoco() && value is IDictionary<string, object> dictionaryValue)
+        {
+            return CreatePocoFromDictionary(dictionaryValue, targetType);
+        }
+
         if (targetType == typeof(DateTime) && value is DateTimeOffset dto)
         {
             return dto.UtcDateTime;
@@ -110,6 +118,43 @@ internal static class McpInputConversionHelper
         }
 
         return null;
+    }
+
+    public static object CreatePocoFromDictionary(IDictionary<string, object> source, Type targetType)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(targetType);
+
+        var poco = Activator.CreateInstance(targetType)
+            ?? throw new InvalidOperationException($"Could not create instance of {targetType}.");
+
+        var properties = _writablePropertyCache.GetOrAdd(
+            targetType,
+            static t => t.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                        .Where(p => p.CanWrite)
+                        .ToArray());
+
+        foreach (var property in properties)
+        {
+            if (!source.TryGetValue(property.Name, out var rawValue))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (TryConvertArgumentToTargetType(rawValue, property.PropertyType, out var convertedValue))
+                {
+                    property.SetValue(poco, convertedValue);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to set property '{property.Name}' on '{targetType.Name}'.", ex);
+            }
+        }
+
+        return poco;
     }
 
     public static bool IsSupportedCollectionType(Type targetType)

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/ToolInvocationPocoConverter.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Converters/ToolInvocationPocoConverter.cs
@@ -28,43 +28,19 @@ internal class ToolInvocationPocoConverter : IInputConverter
 
         try
         {
-            var poco = CreatePocoFromArguments(toolContext.Arguments!, context.TargetType);
+            // Tool arguments arrive as Dictionary<string, object?>, but the shared helper expects
+            // Dictionary<string, object>. Project nulls out so the helper can populate the POCO,
+            // including any nested complex or array-of-complex properties.
+            var arguments = toolContext.Arguments!
+                .Where(kvp => kvp.Value is not null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!, StringComparer.OrdinalIgnoreCase);
+
+            var poco = CreatePocoFromDictionary(arguments, context.TargetType);
             return new ValueTask<ConversionResult>(ConversionResult.Success(poco));
         }
         catch (Exception ex)
         {
             return new ValueTask<ConversionResult>(ConversionResult.Failed(ex));
         }
-    }
-
-    private object? CreatePocoFromArguments(IDictionary<string, object?> arguments, Type targetType)
-    {
-        ArgumentNullException.ThrowIfNull(arguments);
-        ArgumentNullException.ThrowIfNull(targetType);
-
-        var poco = Activator.CreateInstance(targetType);
-
-        foreach (var kvp in arguments)
-        {
-            var property = targetType.GetProperty(kvp.Key);
-            if (property is null || !property.CanWrite)
-            {
-                continue;
-            }
-
-            try
-            {
-                if (TryConvertArgumentToTargetType(kvp.Value, property.PropertyType, out var convertedValue))
-                {
-                    property.SetValue(poco, convertedValue);
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"Failed to set property '{property.Name}'", ex);
-            }
-        }
-
-        return poco;
     }
 }

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -10,7 +10,7 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp <version>
 
-- <entry>
+- Fixed argument conversion so tool properties typed as arrays of complex objects (and POCO trigger properties typed as arrays of complex objects, or as nested complex objects) are populated instead of arriving as `null` elements. (#260)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 

--- a/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
+++ b/test/Worker.Extensions.Mcp.Tests/McpInputConversionHelperTests.cs
@@ -173,6 +173,284 @@ public class McpInputConversionHelperTests
         Assert.Equal(expected, result);
     }
 
+    [Fact]
+    public void TryConvertToTargetType_ArrayOfComplexType_PreservesElementValues()
+    {
+        var input = new List<object?>
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Widget",
+                ["Quantity"] = 3,
+            },
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Gadget",
+                ["Quantity"] = 7,
+            },
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(Item[]), out var result);
+
+        Assert.True(success);
+        Assert.NotNull(result);
+        var items = Assert.IsType<Item[]>(result);
+        Assert.Equal(2, items.Length);
+
+        Assert.NotNull(items[0]);
+        Assert.Equal("Widget", items[0]!.Name);
+        Assert.Equal(3, items[0]!.Quantity);
+
+        Assert.NotNull(items[1]);
+        Assert.Equal("Gadget", items[1]!.Name);
+        Assert.Equal(7, items[1]!.Quantity);
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_ListOfComplexType_PreservesElementValues()
+    {
+        var input = BuildItemDictionaries();
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(List<Item>), out var result);
+
+        Assert.True(success);
+        var items = Assert.IsType<List<Item>>(result);
+        AssertWidgetAndGadget(items);
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_IEnumerableOfComplexType_PreservesElementValues()
+    {
+        var input = BuildItemDictionaries();
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(IEnumerable<Item>), out var result);
+
+        Assert.True(success);
+        var items = (IEnumerable<Item>)result!;
+        AssertWidgetAndGadget(items.ToList());
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_NestedPocoProperty_IsPopulated()
+    {
+        var input = new Dictionary<string, object>
+        {
+            ["Name"] = "Alice",
+            ["Address"] = new Dictionary<string, object>
+            {
+                ["Street"] = "123 Main",
+                ["City"] = "Seattle",
+            },
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(Person), out var result);
+
+        Assert.True(success);
+        var person = Assert.IsType<Person>(result);
+        Assert.Equal("Alice", person.Name);
+        Assert.NotNull(person.Address);
+        Assert.Equal("123 Main", person.Address!.Street);
+        Assert.Equal("Seattle", person.Address.City);
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_PocoWithArrayOfComplexProperty_IsPopulated()
+    {
+        var input = new Dictionary<string, object>
+        {
+            ["Name"] = "Order #1",
+            ["Items"] = BuildItemDictionaries(),
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(OrderWithArray), out var result);
+
+        Assert.True(success);
+        var order = Assert.IsType<OrderWithArray>(result);
+        Assert.Equal("Order #1", order.Name);
+        Assert.NotNull(order.Items);
+        AssertWidgetAndGadget(order.Items!);
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_PocoWithListOfComplexProperty_IsPopulated()
+    {
+        var input = new Dictionary<string, object>
+        {
+            ["Name"] = "Order #2",
+            ["Items"] = BuildItemDictionaries(),
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(OrderWithList), out var result);
+
+        Assert.True(success);
+        var order = Assert.IsType<OrderWithList>(result);
+        Assert.Equal("Order #2", order.Name);
+        Assert.NotNull(order.Items);
+        AssertWidgetAndGadget(order.Items!);
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_PocoWithIEnumerableOfComplexProperty_IsPopulated()
+    {
+        var input = new Dictionary<string, object>
+        {
+            ["Name"] = "Order #3",
+            ["Items"] = BuildItemDictionaries(),
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(OrderWithEnumerable), out var result);
+
+        Assert.True(success);
+        var order = Assert.IsType<OrderWithEnumerable>(result);
+        Assert.Equal("Order #3", order.Name);
+        Assert.NotNull(order.Items);
+        AssertWidgetAndGadget(order.Items!.ToList());
+    }
+
+    [Fact]
+    public void TryConvertToTargetType_DeeplyNested_PocoAndArrayOfPoco_IsPopulated()
+    {
+        // Company -> Department[] -> Employee.Address (POCO)
+        // Exercises: nested POCO inside an element of an array property, plus a POCO property
+        // on that element. Proves the recursion works at arbitrary depth.
+        var input = new Dictionary<string, object>
+        {
+            ["Name"] = "Contoso",
+            ["Departments"] = new List<object?>
+            {
+                new Dictionary<string, object>
+                {
+                    ["Name"] = "Engineering",
+                    ["Lead"] = new Dictionary<string, object>
+                    {
+                        ["Name"] = "Alice",
+                        ["Address"] = new Dictionary<string, object>
+                        {
+                            ["Street"] = "1 Infinite Loop",
+                            ["City"] = "Cupertino",
+                        },
+                    },
+                },
+                new Dictionary<string, object>
+                {
+                    ["Name"] = "Sales",
+                    ["Lead"] = new Dictionary<string, object>
+                    {
+                        ["Name"] = "Bob",
+                        ["Address"] = new Dictionary<string, object>
+                        {
+                            ["Street"] = "350 5th Ave",
+                            ["City"] = "New York",
+                        },
+                    },
+                },
+            },
+        };
+
+        var success = McpInputConversionHelper.TryConvertArgumentToTargetType(input, typeof(Company), out var result);
+
+        Assert.True(success);
+        var company = Assert.IsType<Company>(result);
+        Assert.Equal("Contoso", company.Name);
+        Assert.NotNull(company.Departments);
+        Assert.Equal(2, company.Departments!.Length);
+
+        var eng = company.Departments[0];
+        Assert.Equal("Engineering", eng.Name);
+        Assert.NotNull(eng.Lead);
+        Assert.Equal("Alice", eng.Lead!.Name);
+        Assert.NotNull(eng.Lead.Address);
+        Assert.Equal("1 Infinite Loop", eng.Lead.Address!.Street);
+        Assert.Equal("Cupertino", eng.Lead.Address.City);
+
+        var sales = company.Departments[1];
+        Assert.Equal("Sales", sales.Name);
+        Assert.NotNull(sales.Lead);
+        Assert.Equal("Bob", sales.Lead!.Name);
+        Assert.NotNull(sales.Lead.Address);
+        Assert.Equal("350 5th Ave", sales.Lead.Address!.Street);
+        Assert.Equal("New York", sales.Lead.Address.City);
+    }
+
+    private static List<object?> BuildItemDictionaries() =>
+    [
+        new Dictionary<string, object>
+        {
+            ["Name"] = "Widget",
+            ["Quantity"] = 3,
+        },
+        new Dictionary<string, object>
+        {
+            ["Name"] = "Gadget",
+            ["Quantity"] = 7,
+        },
+    ];
+
+    private static void AssertWidgetAndGadget(IReadOnlyList<Item> items)
+    {
+        Assert.Equal(2, items.Count);
+        Assert.NotNull(items[0]);
+        Assert.Equal("Widget", items[0]!.Name);
+        Assert.Equal(3, items[0]!.Quantity);
+        Assert.NotNull(items[1]);
+        Assert.Equal("Gadget", items[1]!.Name);
+        Assert.Equal(7, items[1]!.Quantity);
+    }
+
+    private class Person
+    {
+        public string? Name { get; set; }
+        public Address? Address { get; set; }
+    }
+
+    private class Address
+    {
+        public string? Street { get; set; }
+        public string? City { get; set; }
+    }
+
+    private class OrderWithArray
+    {
+        public string? Name { get; set; }
+        public Item[]? Items { get; set; }
+    }
+
+    private class OrderWithList
+    {
+        public string? Name { get; set; }
+        public List<Item>? Items { get; set; }
+    }
+
+    private class OrderWithEnumerable
+    {
+        public string? Name { get; set; }
+        public IEnumerable<Item>? Items { get; set; }
+    }
+
+    private class Item
+    {
+        public string? Name { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    private class Company
+    {
+        public string? Name { get; set; }
+        public Department[]? Departments { get; set; }
+    }
+
+    private class Department
+    {
+        public string? Name { get; set; }
+        public Employee? Lead { get; set; }
+    }
+
+    private class Employee
+    {
+        public string? Name { get; set; }
+        public Address? Address { get; set; }
+    }
+
     [TypeConverter(typeof(TestPocoConverter))]
     private class TestPoco
     {


### PR DESCRIPTION
Resolves #260.

## What

Argument conversion in the .NET worker extension previously dropped complex element values to `null` for several reasonable parameter shapes. After this change they round-trip correctly:

- `MyItem[]`, `List<MyItem>`, `IEnumerable<MyItem>` (and `IList<T>`, `ICollection<T>`)
- POCO trigger parameters with a nested POCO property
- POCO trigger parameters with an array, list, or enumerable of complex property
- All of the above at arbitrary nesting depth

## Why it was broken

Tool args arrive in the worker as `Dictionary<string, object>` (with arrays as `List<object?>` and nested objects as nested dictionaries). `McpInputConversionHelper.ConvertArgumentToTargetType` had branches for enum, supported collections, `IConvertible`, and `TypeConverter`, but no `Dictionary` to POCO branch. So inside `ConvertElementIfNeeded` (for collection elements) and inside `ToolInvocationPocoConverter.CreatePocoFromArguments` (for nested properties), complex values silently became `null`.

## What changed

- `McpInputConversionHelper`: add a `Dictionary<string, object>` to POCO branch in `ConvertArgumentToTargetType` plus a shared `CreatePocoFromDictionary` helper. Per-property conversion recurses through `TryConvertArgumentToTargetType`, so the same path handles primitives, collections, nested POCOs, and collections of POCOs at arbitrary depth.
- `ToolInvocationPocoConverter`: delegate to the shared helper so top-level POCO triggers and nested or element conversion share one code path.
- `release_notes.md`: added an entry under the Worker extension section.
- Unit tests cover every shape listed above, including a three-level deep nesting case (`Company > Department[] > Employee.Address`).

## Out of scope

Enriching `PropertyBasedToolInputSchema` so MCP clients see the nested shape via `tools/list` (today it emits `{"items":{"type":"object"}}` with no inner `properties`). Worth a follow-up issue; not blocking this fix because MCP agents that send the right payload now get correct deserialization.

## Validation

- `dotnet test test/Worker.Extensions.Mcp.Tests/Worker.Extensions.Mcp.Tests.csproj`: 526/526 pass.
- `dotnet test test/Worker.Extensions.Mcp.Sdk.Tests/Worker.Extensions.Mcp.Sdk.Tests.csproj`: 80/80 pass.
- `dotnet test test/Extensions.Mcp.Tests/Extensions.Mcp.Tests.csproj`: 378/378 pass.
