### PR TITLE
Release prep for worker ext v1.5.1

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.5.1</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -8,7 +8,7 @@
 
 - Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
 
-### Microsoft.Azure.Functions.Worker.Extensions.Mcp <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.1
 
 - Fixed argument conversion so tool properties typed as arrays of complex objects (and POCO trigger properties typed as arrays of complex objects, or as nested complex objects) are populated instead of arriving as `null` elements. (#260)
 


### PR DESCRIPTION
Bumps the worker extension to **1.5.1** and fills in its `release_notes.md` section.

### Versioning (semver)
The only customer-facing change since `worker-1.5.0` is the bug fix for array, list, and nested POCO tool properties (#260, shipped via #265). A bug fix with no new or breaking API is a **patch** bump: `1.5.0` -> `1.5.1`.

Other commits since the last release are not customer-facing: the .NET SDK bump (#264), the e2e test trim (#263), and the worker notes reset (#259).

### Changes
- `Worker.Extensions.Mcp/Directory.Version.props`: `VersionPrefix` `1.5.0` -> `1.5.1`
- `release_notes.md`: set the worker section heading to `1.5.1` (host and SDK sections stay at `<version>`, pending their own releases)

Build verified clean (`dotnet build -c Release`, resolves to `1.5.1`). No docs or samples pin the worker package version.