### PR TITLE
Advertise Prompts capability in ServerCapabilities

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Configuration/FunctionsMcpServerOptionsSetup.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Configuration/FunctionsMcpServerOptionsSetup.cs
@@ -26,7 +26,8 @@ internal class FunctionsMcpServerOptionsSetup(IOptions<McpOptions> extensionOpti
         options.Capabilities = new ServerCapabilities
         {
             Tools = new ToolsCapability(),
-            Resources = new ResourcesCapability()
+            Resources = new ResourcesCapability(),
+            Prompts = new PromptsCapability()
         };
     }
 }

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -7,6 +7,7 @@
 ### Microsoft.Azure.Functions.Extensions <version>
 
 - Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
+- Advertise `Prompts` in `ServerCapabilities` so spec-compliant MCP clients invoke `prompts/list`.
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.1
 

--- a/test/Extensions.Mcp.Tests/FunctionsMcpServerOptionsSetupTests.cs
+++ b/test/Extensions.Mcp.Tests/FunctionsMcpServerOptionsSetupTests.cs
@@ -45,7 +45,7 @@ public class FunctionsMcpServerOptionsSetupTests
     }
 
     [Fact]
-    public void Configure_SetsCapabilities_WithToolsAndResources()
+    public void Configure_SetsCapabilities_WithToolsResourcesAndPrompts()
     {
         var mcpOptions = new McpOptions();
         var optionsWrapper = Options.Create(mcpOptions);
@@ -57,6 +57,7 @@ public class FunctionsMcpServerOptionsSetupTests
         Assert.NotNull(serverOptions.Capabilities);
         Assert.NotNull(serverOptions.Capabilities.Tools);
         Assert.NotNull(serverOptions.Capabilities.Resources);
+        Assert.NotNull(serverOptions.Capabilities.Prompts);
     }
 
     [Fact]
@@ -86,5 +87,6 @@ public class FunctionsMcpServerOptionsSetupTests
         Assert.NotNull(serverOptions.Capabilities);
         Assert.NotNull(serverOptions.Capabilities.Tools);
         Assert.NotNull(serverOptions.Capabilities.Resources);
+        Assert.NotNull(serverOptions.Capabilities.Prompts);
     }
 }


### PR DESCRIPTION
## Bug

`FunctionsMcpServerOptionsSetup` advertised `ServerCapabilities` with only `Tools` and `Resources`, but prompt handlers (`WithListPromptsHandler`, `WithGetPromptHandler`) are wired in `McpWebJobsBuilderExtensions`. Strictly spec-compliant MCP clients that gate `prompts/list` on `capabilities.prompts` would skip prompts entirely and never see the registered prompt handlers.

Discovered while wiring up the MCP conformance suite.

## Fix

Declare `Prompts = new PromptsCapability()` alongside the existing `Tools` and `Resources` entries. One-line behavior fix, no public API change.

Test coverage in `FunctionsMcpServerOptionsSetupTests` updated to assert the advertised `Prompts` capability.

<!-- resolves #<issue> -->