### PR TITLE
Upgrade MCP C# SDK to 1.4.0 for host extension

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/PromptInvocationContext.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/PromptInvocationContext.cs
@@ -19,7 +19,7 @@ internal sealed class PromptInvocationContext
     /// Gets the arguments provided for the prompt.
     /// </summary>
     [JsonPropertyName("arguments")]
-    public IReadOnlyDictionary<string, JsonElement>? Arguments { get; init; }
+    public IDictionary<string, JsonElement>? Arguments { get; init; }
 
     /// <summary>
     /// Gets the session ID associated with the current prompt invocation.

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/ToolInvocationContext.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Abstractions/ToolInvocationContext.cs
@@ -23,7 +23,7 @@ internal sealed class ToolInvocationContext
     /// Each key-value pair represents a parameter name and its corresponding argument value.
     /// </remarks>
     [JsonPropertyName("arguments")]
-    public IReadOnlyDictionary<string, JsonElement>? Arguments { get; init; }
+    public IDictionary<string, JsonElement>? Arguments { get; init; }
 
 
     /// <summary>

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Extensions.Mcp.csproj
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Extensions.Mcp.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.0" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Extensions.Mcp.csproj
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Extensions.Mcp.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.5" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
@@ -132,24 +132,20 @@ internal sealed class StreamableHttpRequestHandler(
         ThrowIfNotStatelessSession(stateless);
 
         string clientId = Utility.EmptyId;
-        StreamableHttpTransport transport = new()
+        var sessionId = Utility.CreateId();
+        var clientState = ClientStateManager.FormatUriState(sessionId, instanceIdProvider.InstanceId, mcpOptions.Value.EncryptClientState);
+
+        StreamableHttpTransport transport = new(
+            sessionId: sessionId,
+            stateless: true,
+            onSessionInitialized: (initParams, ct) =>
+                {
+                    context.Response.Headers[McpSessionIdHeaderName] = clientState;
+                    return ValueTask.CompletedTask;
+                })
         {
             IsStateless = true,
             SessionContext = new(clientId, instanceIdProvider.InstanceId),
-            OnInitRequestReceived = (t, p) =>
-                {
-                    var sessionId = Utility.CreateId();
-                    var clientState = ClientStateManager.FormatUriState(sessionId, instanceIdProvider.InstanceId, mcpOptions.Value.EncryptClientState);
-
-                    // Persist the session ID in the response header after receiving the initialize request.
-                    // TODO: Persist client information here from `initRequestParams.ClientInfo`
-                    // Do we need any additional client information? With that, if we're limiting to client info, we won't be able to provide
-                    // capabilities and other client details.
-                    t.SessionId = sessionId;
-                    context.Response.Headers[McpSessionIdHeaderName] = clientState;
-
-                    return ValueTask.CompletedTask;
-                }
         };
 
         // Create a new session with the transport.
@@ -167,10 +163,11 @@ internal sealed class StreamableHttpRequestHandler(
             return null;
         }
 
-        var transport = new StreamableHttpTransport
+        var transport = new StreamableHttpTransport(
+            sessionId: clientId,
+            stateless: true)
         {
             IsStateless = true,
-            SessionId = clientId,
             SessionContext = new(clientId, instanceIdProvider.InstanceId)
         };
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
@@ -133,13 +133,14 @@ internal sealed class StreamableHttpRequestHandler(
 
         string clientId = Utility.EmptyId;
         var sessionId = Utility.CreateId();
-        var clientState = ClientStateManager.FormatUriState(sessionId, instanceIdProvider.InstanceId, mcpOptions.Value.EncryptClientState);
 
         StreamableHttpTransport transport = new(
             sessionId: sessionId,
             stateless: true,
             onSessionInitialized: (initParams, ct) =>
                 {
+                    // Persist the session ID in the response header after receiving the initialize request.
+                    var clientState = ClientStateManager.FormatUriState(sessionId, instanceIdProvider.InstanceId, mcpOptions.Value.EncryptClientState);
                     context.Response.Headers[McpSessionIdHeaderName] = clientState;
                     return ValueTask.CompletedTask;
                 })

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpRequestHandler.cs
@@ -136,7 +136,7 @@ internal sealed class StreamableHttpRequestHandler(
 
         StreamableHttpTransport transport = new(
             sessionId: sessionId,
-            stateless: true,
+            stateless: true, // SDK transport property — controls SDK-level stateless behavior
             onSessionInitialized: (initParams, ct) =>
                 {
                     // Persist the session ID in the response header after receiving the initialize request.
@@ -145,7 +145,7 @@ internal sealed class StreamableHttpRequestHandler(
                     return ValueTask.CompletedTask;
                 })
         {
-            IsStateless = true,
+            IsStateless = true, // Host wrapper property — controls host session management
             SessionContext = new(clientId, instanceIdProvider.InstanceId),
         };
 

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
@@ -7,8 +7,6 @@ using ModelContextProtocol.Server;
 
 internal sealed class StreamableHttpTransport : McpExtensionTransport<StreamableHttpServerTransport>
 {
-    private string? _sessionId;
-
     public StreamableHttpTransport(
         string? sessionId = null,
         bool stateless = false,
@@ -22,7 +20,6 @@ internal sealed class StreamableHttpTransport : McpExtensionTransport<Streamable
             OnSessionInitialized = onSessionInitialized,
         })
     {
-        _sessionId = sessionId;
     }
 
     public override Task HandleMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken)
@@ -30,10 +27,12 @@ internal sealed class StreamableHttpTransport : McpExtensionTransport<Streamable
         throw new NotSupportedException();
     }
 
+    // SessionId is init-only on StreamableHttpServerTransport (SDK 1.2.0),
+    // so we delegate the getter to the SDK transport and reject post-construction mutation.
     public override string? SessionId
     {
-        get => _sessionId;
-        set => _sessionId = value;
+        get => Transport.SessionId;
+        set => throw new NotSupportedException("SessionId is immutable after transport construction.");
     }
 
     public Task HandleGetRequestAsync(Stream sseResponseStream, CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
@@ -1,15 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO.Pipelines;
 using Microsoft.Azure.Functions.Extensions.Mcp;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
-internal sealed class StreamableHttpTransport(bool flowExecutionContext = false)
-    : McpExtensionTransport<StreamableHttpServerTransport>(new StreamableHttpServerTransport() { FlowExecutionContextFromRequests = flowExecutionContext })
+internal sealed class StreamableHttpTransport : McpExtensionTransport<StreamableHttpServerTransport>
 {
-    private Func<StreamableHttpTransport, InitializeRequestParams?, ValueTask>? _onInitRequestReceived;
+    private string? _sessionId;
+
+    public StreamableHttpTransport(
+        string? sessionId = null,
+        bool stateless = false,
+        bool flowExecutionContext = false,
+        Func<InitializeRequestParams, CancellationToken, ValueTask>? onSessionInitialized = null)
+        : base(new StreamableHttpServerTransport()
+        {
+            SessionId = sessionId,
+            Stateless = stateless,
+            FlowExecutionContextFromRequests = flowExecutionContext,
+            OnSessionInitialized = onSessionInitialized,
+        })
+    {
+        _sessionId = sessionId;
+    }
 
     public override Task HandleMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken)
     {
@@ -18,8 +32,8 @@ internal sealed class StreamableHttpTransport(bool flowExecutionContext = false)
 
     public override string? SessionId
     {
-        get => Transport.SessionId;
-        set => Transport.SessionId = value;
+        get => _sessionId;
+        set => _sessionId = value;
     }
 
     public Task HandleGetRequestAsync(Stream sseResponseStream, CancellationToken cancellationToken)
@@ -29,15 +43,4 @@ internal sealed class StreamableHttpTransport(bool flowExecutionContext = false)
         => Transport.HandlePostRequestAsync(message, responseStream, cancellationToken);
 
     public bool FlowExecutionContextFromRequests => Transport.FlowExecutionContextFromRequests;
-
-    public Func<StreamableHttpTransport, InitializeRequestParams?, ValueTask>? OnInitRequestReceived
-    {
-        get => _onInitRequestReceived;
-        set
-        {
-            _onInitRequestReceived = value;
-            Transport.OnInitRequestReceived = requestParams
-                => _onInitRequestReceived?.Invoke(this, requestParams) ?? ValueTask.CompletedTask;
-        }
-    }
 }

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
@@ -27,7 +27,7 @@ internal sealed class StreamableHttpTransport : McpExtensionTransport<Streamable
         throw new NotSupportedException();
     }
 
-    // SessionId is init-only on StreamableHttpServerTransport,
+    // SessionId is init-only on StreamableHttpServerTransport
     // so we delegate the getter to the SDK transport and reject post-construction mutation.
     public override string? SessionId
     {

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Http/StreamableHttpTransport.cs
@@ -27,7 +27,7 @@ internal sealed class StreamableHttpTransport : McpExtensionTransport<Streamable
         throw new NotSupportedException();
     }
 
-    // SessionId is init-only on StreamableHttpServerTransport (SDK 1.2.0),
+    // SessionId is init-only on StreamableHttpServerTransport,
     // so we delegate the getter to the SDK transport and reject post-construction mutation.
     public override string? SessionId
     {

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ResourceReturnValueBinder.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ResourceReturnValueBinder.cs
@@ -57,12 +57,7 @@ internal sealed class ResourceReturnValueBinder(
         {
             var blobResult = new ReadResourceResult
             {
-                Contents = [new BlobResourceContents
-                {
-                    Uri = ResolvedUri,
-                    MimeType = resourceAttribute.MimeType,
-                    Blob = Convert.ToBase64String(binaryData)
-                }]
+                Contents = [BlobResourceContents.FromBytes(binaryData, ResolvedUri, resourceAttribute.MimeType)]
             };
 
             executionContext.SetResult(blobResult);

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ToolReturnValueBinder.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ToolReturnValueBinder.cs
@@ -89,7 +89,10 @@ internal sealed class ToolReturnValueBinder(CallToolExecutionContext executionCo
     {
         if (!string.IsNullOrEmpty(result.StructuredContent))
         {
-            return JsonSerializer.Deserialize<JsonElement>(result.StructuredContent!, McpJsonUtilities.DefaultOptions);
+            var element = JsonSerializer.Deserialize<JsonElement>(result.StructuredContent!, McpJsonUtilities.DefaultOptions);
+            return element.ValueKind != JsonValueKind.Null
+                ? element
+                : throw new InvalidOperationException("Failed to deserialize structured content.");
         }
 
         return null;

--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ToolReturnValueBinder.cs
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Trigger/ToolReturnValueBinder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Microsoft.Azure.Functions.Extensions.Mcp.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using ModelContextProtocol;
@@ -43,7 +42,7 @@ internal sealed class ToolReturnValueBinder(CallToolExecutionContext executionCo
             }
 
             IList<ContentBlock> contentBlocks = DeserializeToContentBlockCollection(result);
-            JsonNode? structuredContent = DeserializeToStructuredContent(result);
+            JsonElement? structuredContent = DeserializeToStructuredContent(result);
 
             if (contentBlocks.Count == 0)
             {
@@ -86,12 +85,11 @@ internal sealed class ToolReturnValueBinder(CallToolExecutionContext executionCo
         return [contentBlock];
     }
 
-    private static JsonNode? DeserializeToStructuredContent(McpToolResult result)
+    private static JsonElement? DeserializeToStructuredContent(McpToolResult result)
     {
         if (!string.IsNullOrEmpty(result.StructuredContent))
         {
-            return JsonSerializer.Deserialize<JsonNode>(result.StructuredContent!, McpJsonUtilities.DefaultOptions)
-                ?? throw new InvalidOperationException($"Failed to deserialize structured content.");
+            return JsonSerializer.Deserialize<JsonElement>(result.StructuredContent!, McpJsonUtilities.DefaultOptions);
         }
 
         return null;

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -18,5 +18,5 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
-- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.2.0 (#222)
+- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.4.0
 - Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -8,6 +8,9 @@
 
 - Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
 - Advertise `Prompts` in `ServerCapabilities` so spec-compliant MCP clients invoke `prompts/list`.
+- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.4.0
+- Fixed typo in JSON property name `sessionId` on `Transport` class (#206)
+- Add support for resource templates (#200)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.1
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -16,5 +16,5 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
-- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.4.0
+- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.2.0 (#222)
 - Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -9,8 +9,6 @@
 - Added `UseResultSchema` to `McpPromptTriggerAttribute`. When set by the worker, the host unwraps the `McpPromptResult` envelope produced by the worker instead of inferring the shape from the JSON. (#212)
 - Advertise `Prompts` in `ServerCapabilities` so spec-compliant MCP clients invoke `prompts/list`.
 - Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.4.0
-- Fixed typo in JSON property name `sessionId` on `Transport` class (#206)
-- Add support for resource templates (#200)
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.5.1
 

--- a/test/Extensions.Mcp.Tests/Helpers/CallToolExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/CallToolExecutionContextHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
 public static class CallToolExecutionContextHelper
 {
     internal static CallToolExecutionContext CreateExecutionContext(string toolName = "MyTool",
-                                                                   IReadOnlyDictionary<string, JsonElement>? args = null,
+                                                                   IDictionary<string, JsonElement>? args = null,
                                                                    string? sessionId = "session-123",
                                                                    Implementation? clientInfo = null,
                                                                    IHttpContextAccessor? httpContextAccessor = null)
@@ -39,15 +39,19 @@ public static class CallToolExecutionContextHelper
             services.AddSingleton(httpContextAccessor);
         }
 
+#pragma warning disable MCPEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         var mockServer = new Mock<McpServer>();
+#pragma warning restore MCPEXP002
         mockServer.Setup(s=> s.SessionId).Returns(sessionId);
         mockServer.Setup(s => s.ClientInfo).Returns(clientInfo);
 
+#pragma warning disable MCP9003 // Use the constructor overload that accepts a parameters argument.
         RequestContext<CallToolRequestParams> requestContext = new(mockServer.Object, new JsonRpcRequest() { Method = RequestMethods.ToolsCall})
         {
             Params = requestParams,
             Services = services.BuildServiceProvider()
         };
+#pragma warning restore MCP9003
 
         CallToolExecutionContext executionContext = new(requestContext);
 

--- a/test/Extensions.Mcp.Tests/Helpers/CallToolExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/CallToolExecutionContextHelper.cs
@@ -45,13 +45,10 @@ public static class CallToolExecutionContextHelper
         mockServer.Setup(s=> s.SessionId).Returns(sessionId);
         mockServer.Setup(s => s.ClientInfo).Returns(clientInfo);
 
-#pragma warning disable MCP9003 // Use the constructor overload that accepts a parameters argument.
-        RequestContext<CallToolRequestParams> requestContext = new(mockServer.Object, new JsonRpcRequest() { Method = RequestMethods.ToolsCall})
+        RequestContext<CallToolRequestParams> requestContext = new(mockServer.Object, new JsonRpcRequest() { Method = RequestMethods.ToolsCall}, requestParams)
         {
-            Params = requestParams,
             Services = services.BuildServiceProvider()
         };
-#pragma warning restore MCP9003
 
         CallToolExecutionContext executionContext = new(requestContext);
 

--- a/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
@@ -14,7 +14,7 @@ public static class GetPromptExecutionContextHelper
 {
     internal static GetPromptExecutionContext CreateExecutionContext(
         string promptName = "TestPrompt",
-        IReadOnlyDictionary<string, JsonElement>? args = null,
+        IDictionary<string, JsonElement>? args = null,
         string? sessionId = "session-123",
         Implementation? clientInfo = null,
         IHttpContextAccessor? httpContextAccessor = null)

--- a/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
@@ -40,9 +40,9 @@ public static class GetPromptExecutionContextHelper
 
         var requestContext = new RequestContext<GetPromptRequestParams>(
             mockServer.Object,
-            new JsonRpcRequest() { Method = RequestMethods.PromptsGet })
+            new JsonRpcRequest() { Method = RequestMethods.PromptsGet },
+            requestParams)
         {
-            Params = requestParams,
             Services = services.BuildServiceProvider()
         };
 

--- a/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/GetPromptExecutionContextHelper.cs
@@ -34,7 +34,9 @@ public static class GetPromptExecutionContextHelper
             services.AddSingleton(httpContextAccessor);
         }
 
+#pragma warning disable MCPEXP002
         var mockServer = new Mock<McpServer>();
+#pragma warning restore MCPEXP002
         mockServer.Setup(s => s.SessionId).Returns(sessionId);
         mockServer.Setup(s => s.ClientInfo).Returns(clientInfo);
 

--- a/test/Extensions.Mcp.Tests/Helpers/ReadResourceExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/ReadResourceExecutionContextHelper.cs
@@ -37,15 +37,13 @@ public static class ReadResourceExecutionContextHelper
         mockServer.Setup(s => s.SessionId).Returns(sessionId);
         mockServer.Setup(s => s.ClientInfo).Returns(clientInfo);
 
-#pragma warning disable MCP9003 // Use the constructor overload that accepts a parameters argument.
         var requestContext = new RequestContext<ReadResourceRequestParams>(
             mockServer.Object,
-            new JsonRpcRequest() { Method = RequestMethods.ResourcesRead })
+            new JsonRpcRequest() { Method = RequestMethods.ResourcesRead },
+            requestParams)
         {
-            Params = requestParams,
             Services = services.BuildServiceProvider()
         };
-#pragma warning restore MCP9003
 
         var executionContext = new ReadResourceExecutionContext(requestContext);
 

--- a/test/Extensions.Mcp.Tests/Helpers/ReadResourceExecutionContextHelper.cs
+++ b/test/Extensions.Mcp.Tests/Helpers/ReadResourceExecutionContextHelper.cs
@@ -31,10 +31,13 @@ public static class ReadResourceExecutionContextHelper
             services.AddSingleton(httpContextAccessor);
         }
 
+#pragma warning disable MCPEXP002 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         var mockServer = new Mock<McpServer>();
+#pragma warning restore MCPEXP002
         mockServer.Setup(s => s.SessionId).Returns(sessionId);
         mockServer.Setup(s => s.ClientInfo).Returns(clientInfo);
 
+#pragma warning disable MCP9003 // Use the constructor overload that accepts a parameters argument.
         var requestContext = new RequestContext<ReadResourceRequestParams>(
             mockServer.Object,
             new JsonRpcRequest() { Method = RequestMethods.ResourcesRead })
@@ -42,6 +45,7 @@ public static class ReadResourceExecutionContextHelper
             Params = requestParams,
             Services = services.BuildServiceProvider()
         };
+#pragma warning restore MCP9003
 
         var executionContext = new ReadResourceExecutionContext(requestContext);
 

--- a/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
@@ -14,7 +14,7 @@ public class McpPromptListenerTests
 {
     private static RequestContext<GetPromptRequestParams> CreateRequest(
         string name = "TestPrompt",
-        IReadOnlyDictionary<string, JsonElement>? arguments = null)
+        IDictionary<string, JsonElement>? arguments = null)
     {
         var server = new Mock<McpServer>().Object;
         var parameters = new GetPromptRequestParams { Name = name, Arguments = arguments };

--- a/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
@@ -19,10 +19,7 @@ public class McpPromptListenerTests
         var server = new Mock<McpServer>().Object;
         var parameters = new GetPromptRequestParams { Name = name, Arguments = arguments };
 
-        return new RequestContext<GetPromptRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.PromptsGet })
-        {
-            Params = parameters
-        };
+        return new RequestContext<GetPromptRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.PromptsGet }, parameters);
     }
 
     private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement;

--- a/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpPromptListenerTests.cs
@@ -16,7 +16,9 @@ public class McpPromptListenerTests
         string name = "TestPrompt",
         IDictionary<string, JsonElement>? arguments = null)
     {
+#pragma warning disable MCPEXP002
         var server = new Mock<McpServer>().Object;
+#pragma warning restore MCPEXP002
         var parameters = new GetPromptRequestParams { Name = name, Arguments = arguments };
 
         return new RequestContext<GetPromptRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.PromptsGet }, parameters);

--- a/test/Extensions.Mcp.Tests/McpResourceListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpResourceListenerTests.cs
@@ -17,12 +17,7 @@ public class McpResourceListenerTests
 #pragma warning restore MCPEXP002
         var parameters = new ReadResourceRequestParams { Uri = uri };
 
-#pragma warning disable MCP9003
-        return new RequestContext<ReadResourceRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ResourcesRead })
-        {
-            Params = parameters
-        };
-#pragma warning restore MCP9003
+        return new RequestContext<ReadResourceRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ResourcesRead }, parameters);
     }
 
     [Fact]

--- a/test/Extensions.Mcp.Tests/McpResourceListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpResourceListenerTests.cs
@@ -12,13 +12,17 @@ public class McpResourceListenerTests
 {
     private static RequestContext<ReadResourceRequestParams> CreateRequest(string uri = "test://resource/1")
     {
+#pragma warning disable MCPEXP002
         var server = new Mock<McpServer>().Object;
+#pragma warning restore MCPEXP002
         var parameters = new ReadResourceRequestParams { Uri = uri };
 
+#pragma warning disable MCP9003
         return new RequestContext<ReadResourceRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ResourcesRead })
         {
             Params = parameters
         };
+#pragma warning restore MCP9003
     }
 
     [Fact]

--- a/test/Extensions.Mcp.Tests/McpToolListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpToolListenerTests.cs
@@ -25,13 +25,17 @@ public class McpToolListenerTests
     private static RequestContext<CallToolRequestParams> CreateRequest(params (string key, JsonElement value)[] args)
     {
         var dict = args?.ToDictionary(x => x.key, x => x.value) ?? new Dictionary<string, JsonElement>();
+#pragma warning disable MCPEXP002
         var server = new Mock<McpServer>().Object;
+#pragma warning restore MCPEXP002
         var parameters = new CallToolRequestParams { Name = "params", Arguments = dict };
 
+#pragma warning disable MCP9003
         return new RequestContext<CallToolRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ToolsCall })
         {
             Params = parameters
         };
+#pragma warning restore MCP9003
     }
 
     private static CallToolRequestParams CreateRequestParams(params (string key, JsonElement value)[] args)

--- a/test/Extensions.Mcp.Tests/McpToolListenerTests.cs
+++ b/test/Extensions.Mcp.Tests/McpToolListenerTests.cs
@@ -30,12 +30,7 @@ public class McpToolListenerTests
 #pragma warning restore MCPEXP002
         var parameters = new CallToolRequestParams { Name = "params", Arguments = dict };
 
-#pragma warning disable MCP9003
-        return new RequestContext<CallToolRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ToolsCall })
-        {
-            Params = parameters
-        };
-#pragma warning restore MCP9003
+        return new RequestContext<CallToolRequestParams>(server, new JsonRpcRequest() { Method = RequestMethods.ToolsCall }, parameters);
     }
 
     private static CallToolRequestParams CreateRequestParams(params (string key, JsonElement value)[] args)

--- a/test/Extensions.Mcp.Tests/ResourceReturnValueBinderTests.cs
+++ b/test/Extensions.Mcp.Tests/ResourceReturnValueBinderTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Extensions.Mcp.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
@@ -88,7 +90,7 @@ public class ResourceReturnValueBinderTests
         var blobContent = Assert.IsType<BlobResourceContents>(result.Contents[0]);
         Assert.Equal("test://resource/1", blobContent.Uri);
         Assert.Equal("application/octet-stream", blobContent.MimeType);
-        Assert.Equal(Convert.ToBase64String(binaryData), blobContent.Blob);
+        Assert.Equal(Convert.ToBase64String(binaryData), Encoding.UTF8.GetString(blobContent.Blob.Span));
     }
 
     [Fact]
@@ -131,13 +133,13 @@ public class ResourceReturnValueBinderTests
         var blobContent = new BlobResourceContents
         {
             Uri = "test://resource/1",
-            Blob = binaryData,
+            Blob = Encoding.UTF8.GetBytes(binaryData),
             MimeType = "image/png"
         };
 
         var mcpResult = new McpResourceResult
         {
-            Content = JsonSerializer.Serialize(blobContent, McpJsonSerializerOptions.DefaultOptions)
+            Content = JsonSerializer.Serialize((ResourceContents)blobContent, McpJsonUtilities.DefaultOptions)
         };
 
         var jsonString = JsonSerializer.Serialize(mcpResult, McpJsonSerializerOptions.DefaultOptions);
@@ -151,7 +153,7 @@ public class ResourceReturnValueBinderTests
         var resultContent = Assert.IsType<BlobResourceContents>(result.Contents[0]);
         Assert.Equal("test://resource/1", resultContent.Uri);
         Assert.Equal("image/png", resultContent.MimeType);
-        Assert.Equal(binaryData, resultContent.Blob);
+        Assert.Equal(binaryData, Encoding.UTF8.GetString(resultContent.Blob.Span));
     }
 
     [Fact]
@@ -297,7 +299,7 @@ public class ResourceReturnValueBinderTests
         Assert.Single(result.Contents);
         
         var blobContent = Assert.IsType<BlobResourceContents>(result.Contents[0]);
-        Assert.Equal(Convert.ToBase64String(binaryData), blobContent.Blob);
+        Assert.Equal(Convert.ToBase64String(binaryData), Encoding.UTF8.GetString(blobContent.Blob.Span));
     }
 
     [Fact]

--- a/test/Extensions.Mcp.Tests/ToolReturnValueBinderTests.cs
+++ b/test/Extensions.Mcp.Tests/ToolReturnValueBinderTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text;
 using System.Text.Json;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Microsoft.Azure.Functions.Extensions.Mcp.Tests;
@@ -41,11 +43,11 @@ public class ToolReturnValueBinderTests
         var binder = new ToolReturnValueBinder(context);
 
         var data = Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 });
-        var innerBlock = new AudioContentBlock { Data = data, MimeType = "audio/mpeg", };
+        ContentBlock innerBlock = new AudioContentBlock { Data = Encoding.UTF8.GetBytes(data), MimeType = "audio/mpeg", };
         var mcpToolResult = new McpToolResult
         {
             Type = "audio",
-            Content = JsonSerializer.Serialize(innerBlock)
+            Content = JsonSerializer.Serialize(innerBlock, McpJsonUtilities.DefaultOptions)
         };
         var json = JsonSerializer.Serialize(mcpToolResult);
 
@@ -54,8 +56,8 @@ public class ToolReturnValueBinderTests
         var result = Assert.IsType<CallToolResult>(await context.ResultTask);
         var audioBlock = Assert.Single(result.Content) as AudioContentBlock;
         Assert.NotNull(audioBlock);
-        Assert.Equal(innerBlock.MimeType, audioBlock!.MimeType);
-        Assert.Equal(innerBlock.Data, audioBlock.Data);
+        Assert.Equal("audio/mpeg", audioBlock!.MimeType);
+        Assert.Equal(((AudioContentBlock)innerBlock).Data, audioBlock.Data);
     }
 
     [Fact]
@@ -65,11 +67,11 @@ public class ToolReturnValueBinderTests
         var binder = new ToolReturnValueBinder(context);
 
         var data = Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 });
-        var innerBlock = new ImageContentBlock { Data = data, MimeType = "image/png", };
+        ContentBlock innerBlock = new ImageContentBlock { Data = Encoding.UTF8.GetBytes(data), MimeType = "image/png", };
         var mcpToolResult = new McpToolResult
         {
             Type = "image",
-            Content = JsonSerializer.Serialize(innerBlock)
+            Content = JsonSerializer.Serialize(innerBlock, McpJsonUtilities.DefaultOptions)
         };
         var json = JsonSerializer.Serialize(mcpToolResult);
 
@@ -78,8 +80,8 @@ public class ToolReturnValueBinderTests
         var result = Assert.IsType<CallToolResult>(await context.ResultTask);
         var imageBlock = Assert.Single(result.Content) as ImageContentBlock;
         Assert.NotNull(imageBlock);
-        Assert.Equal(innerBlock.MimeType, imageBlock!.MimeType);
-        Assert.Equal(innerBlock.Data, imageBlock.Data);
+        Assert.Equal("image/png", imageBlock!.MimeType);
+        Assert.Equal(((ImageContentBlock)innerBlock).Data, imageBlock.Data);
     }
 
     [Fact]
@@ -94,6 +96,7 @@ public class ToolReturnValueBinderTests
             {
                 Uri = "urn:example",
                 MimeType = "text/plain",
+                Text = "",
             },
         };
         var mcpToolResult = new McpToolResult
@@ -252,7 +255,7 @@ public class ToolReturnValueBinderTests
 
         var imageBlock = (ImageContentBlock)result.Content[1];
         Assert.Equal("image/png", imageBlock.MimeType);
-        Assert.Equal("AQID", imageBlock.Data);
+        Assert.Equal("AQID", Encoding.UTF8.GetString(imageBlock.Data.Span));
 
         var linkBlock = (ResourceLinkBlock)result.Content[2];
         Assert.Equal("https://example.com/resource", linkBlock.Uri);
@@ -268,12 +271,12 @@ public class ToolReturnValueBinderTests
 
         var img1 = new ImageContentBlock
         {
-            Data = Convert.ToBase64String(new byte[] { 1, 2, 3 }),
+            Data = Encoding.UTF8.GetBytes(Convert.ToBase64String(new byte[] { 1, 2, 3 })),
             MimeType = "image/png"
         };
         var img2 = new ImageContentBlock
         {
-            Data = Convert.ToBase64String(new byte[] { 9, 8, 7, 6 }),
+            Data = Encoding.UTF8.GetBytes(Convert.ToBase64String(new byte[] { 9, 8, 7, 6 })),
             MimeType = "image/jpeg"
         };
 
@@ -281,7 +284,7 @@ public class ToolReturnValueBinderTests
         var mcpToolResult = new McpToolResult
         {
             Type = "multi_content_result",
-            Content = JsonSerializer.Serialize(new[] { img1, img2 })
+            Content = JsonSerializer.Serialize(new ContentBlock[] { img1, img2 }, McpJsonUtilities.DefaultOptions)
         };
         var json = JsonSerializer.Serialize(mcpToolResult);
 
@@ -351,7 +354,7 @@ public class ToolReturnValueBinderTests
             Content = new List<ContentBlock>
             {
                 new TextContentBlock { Text = "Hello from CallToolResult" },
-                new ImageContentBlock { Data = "base64data", MimeType = "image/png" }
+                new ImageContentBlock { Data = Encoding.UTF8.GetBytes("base64data"), MimeType = "image/png" }
             },
             StructuredContent = null
         };
@@ -388,7 +391,7 @@ public class ToolReturnValueBinderTests
             {
                 new TextContentBlock { Text = JsonSerializer.Serialize(structuredData) }
             },
-            StructuredContent = System.Text.Json.Nodes.JsonNode.Parse(JsonSerializer.Serialize(structuredData))
+            StructuredContent = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(structuredData))
         };
 
         var mcpToolResult = new McpToolResult


### PR DESCRIPTION
Upgrades `ModelContextProtocol` from `0.4.0-preview.3` to `1.4.0` and
`System.Net.ServerSentEvents` from `10.0.0` to `10.0.7` in the host extension (`Extensions.Mcp`) project.

> **Note:** This is a revival of #224 (SDK 1.2.0), rebased onto latest `main` and bumped to 1.4.0.

### Breaking changes addressed

#### Init-only `StreamableHttpServerTransport` properties

SDK 1.2.0 made `SessionId`, `Stateless`, and `OnSessionInitialized` init-only. We can no
longer set them post-construction, so all configuration moved into the constructor and
object initializer. Our `StreamableHttpTransport` wrapper's `SessionId` getter delegates to
`Transport.SessionId` and the setter throws `NotSupportedException` — no shadow field
needed. The ID is generated before construction and passed in.

#### `OnInitRequestReceived` → `OnSessionInitialized`

The old callback was removed and replaced with `OnSessionInitialized`, which has a
different signature: non-nullable `InitializeRequestParams` and an added
`CancellationToken`. Since it's also init-only, we pass it through the constructor. The
`clientState` is created inside the callback (depends on session being initialized), while
only `sessionId` is captured from the outer scope (needed for the init-only constructor).

#### `StructuredContent`: `JsonNode?` → `JsonElement?`

`CallToolResult.StructuredContent` changed from `JsonNode?` to `JsonElement?`. Since
`JsonElement` is a value type, `Deserialize<JsonElement>()` never returns null — the `??`
operator doesn't compile. Replaced with a `ValueKind != JsonValueKind.Null` guard.

#### `BlobResourceContents.Blob` setter removed

The `Blob` property no longer has a public setter. Replaced direct assignment with
`BlobResourceContents.FromBytes()` factory method.

#### Binary data properties: `string` → `ReadOnlyMemory<byte>`

`ImageContentBlock.Data` and `AudioContentBlock.Data` changed from `string` to
`ReadOnlyMemory<byte>`. The critical discovery: these must be serialized through base types
(`ContentBlock`, `ResourceContents`), not concrete types. The SDK's polymorphic converter
only activates through the base type — direct concrete serialization uses STJ's default
base64 converter, causing double encoding.

#### `Arguments`: `IReadOnlyDictionary` → `IDictionary`

`CallToolRequestParams.Arguments` changed to `IDictionary`. Updated
`ToolInvocationContext.Arguments` and `PromptInvocationContext.Arguments` to match. All
consumers only read from it, so no behavioral change.

#### `RequestContext<T>` 2-arg constructor deprecated

The 2-arg constructor was marked obsolete (MCP9003). Migrated all test call sites to the
3-arg constructor.

### Design notes

- **`IsStateless` vs `Stateless`**: Two separate properties on different layers —
`Stateless` on the SDK transport (init-only, controls SDK behavior), `IsStateless` on our
`McpExtensionTransport` wrapper (controls host session management). Both must be set; not
redundant.

### Changes

**Source** (7 files):
- `StreamableHttpTransport.cs` — Rewritten for init-only SDK
- `StreamableHttpRequestHandler.cs` — Updated session creation pattern
- `ToolReturnValueBinder.cs` — `JsonNode?` → `JsonElement?` with value-type null guard
- `ResourceReturnValueBinder.cs` — `BlobResourceContents.FromBytes()` factory
- `PromptInvocationContext.cs` / `ToolInvocationContext.cs` — `IReadOnlyDictionary` → `IDictionary`
- `Extensions.Mcp.csproj` — Package version bumps (SDK 1.4.0, SSE 10.0.7)

**Tests** (9 files):
- Migrated to 3-arg `RequestContext` constructor
- Updated serialization assertions for `JsonElement` and `ReadOnlyMemory<byte>`
- Zero E2E test changes

### Checklist

- [x] Release notes updated
- [x] Unit tests pass (378/378)