### PR TITLE
Upgrade ModelContextProtocol SDK to 1.4.0

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Worker.Extensions.Mcp.Sdk.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Worker.Extensions.Mcp.Sdk.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -15,5 +15,5 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
-- Upgraded MCP C# SDK dependency from 0.4.0-preview.3 to 1.2.0 (#222)
+- Upgraded MCP C# SDK dependency from 1.2.0 to 1.4.0
 - Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -15,5 +15,5 @@
 
 ### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
 
-- Upgraded MCP C# SDK dependency from 1.2.0 to 1.4.0
+- Upgraded MCP C# SDK dependency to 1.4.0 (#276)
 - Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)


### PR DESCRIPTION
## Summary

Upgrades the MCP C# SDK dependency (`ModelContextProtocol`) in `Worker.Extensions.Mcp.Sdk` from **1.2.0** to **1.4.0**.

## Changes

- **`Worker.Extensions.Mcp.Sdk.csproj`** — Updated `ModelContextProtocol` package version from 1.2.0 to 1.4.0
- **`release_notes.md`** — Updated release notes to reflect the version bump

## Validation

- ✅ Build succeeds with 0 warnings, 0 errors
- ✅ All 80 SDK tests pass