### PR TITLE
Release prep

### DIFF
--- a/src/Microsoft.Azure.Functions.Extensions.Mcp/Directory.Version.props
+++ b/src/Microsoft.Azure.Functions.Extensions.Mcp/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Directory.Version.props
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk/Directory.Version.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.4</VersionSuffix>
+    <VersionSuffix>preview.5</VersionSuffix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Mcp/Directory.Version.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -4,15 +4,17 @@
 - My change description (#PR/#issue)
 -->
 
-### Microsoft.Azure.Functions.Extensions <version>
+### Microsoft.Azure.Functions.Extensions.Mcp 1.6.0
 
-- Advertise `Prompts` in `ServerCapabilities` so spec-compliant MCP clients invoke `prompts/list`. (#271)
+- Refactored token utility to use dedicated `IUriStateProtector` abstraction (#268)
+- Advertise `Prompts` in `ServerCapabilities` so spec-compliant MCP clients invoke `prompts/list` (#271)
+- Added `UseResultSchema` to `McpPromptTriggerAttribute` for unwrapping `McpPromptResult` envelopes (#212)
 
-### Microsoft.Azure.Functions.Worker.Extensions.Mcp <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Mcp 1.6.0
 
-- <entry>
+- Updated to ship with host extension 1.6.0
 
-### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk <version>
+### Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk 1.0.0-preview.5
 
-- Upgraded MCP C# SDK dependency to 1.4.0 (#276)
+- Upgraded MCP C# SDK dependency from 1.2.0 to 1.4.0 (#276)
 - Add support for strongly-typed prompt trigger return types: `GetPromptResult`, `PromptMessage`, and `IList<PromptMessage>` (#212)


### PR DESCRIPTION
## Summary

Prepares release packages.

### Version bumps
| Package | Previous | New |
|---------|----------|-----|
| Microsoft.Azure.Functions.Extensions.Mcp | 1.5.0 | 1.6.0 |
| Microsoft.Azure.Functions.Worker.Extensions.Mcp | 1.5.1 | 1.6.0 |
| Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk | 1.0.0-preview.4 | 1.0.0-preview.5 |

### Release notes updated
- Added token utility refactor entry (#268) for host extension
- Kept unreleased entries: prompts capability (#271), prompt SDK support (#212), MCP SDK 1.4.0 (#276)
- Cleared stale placeholder `<entry>` from worker section
- Replaced `<version>` placeholders with actual version numbers

### Changes included in this release
**Host extension (1.6.0):**
- Token utility refactored to use `IUriStateProtector`  (#268)
- Advertise Prompts in ServerCapabilities (#271)
- `UseResultSchema` on `McpPromptTriggerAttribute` (#212)

**Worker extension (1.6.0):**
- Ships updated host extension 1.6.0

**Worker SDK (1.0.0-preview.5):**
- MCP C# SDK upgraded to 1.4.0 (#276)
- Strongly-typed prompt trigger return types (#212)