### PR TITLE
Switch CI core tools install to Azure Functions CDN

### DIFF
--- a/eng/ci/templates/scripts/setup-e2e-tests.ps1
+++ b/eng/ci/templates/scripts/setup-e2e-tests.ps1
@@ -49,7 +49,7 @@ else
   $version = $cliFeed.tags.v4.release
   Write-Host "Latest Core Tools version: $version"
 
-  $release = $cliFeed.releases.$version
+  $release = $cliFeed.releases.PSObject.Properties[$version].Value
   if (-not $release) {
     Write-Error "Could not find release '$version' in the CLI feed"
     exit 1

--- a/eng/ci/templates/scripts/setup-e2e-tests.ps1
+++ b/eng/ci/templates/scripts/setup-e2e-tests.ps1
@@ -55,7 +55,7 @@ else
     exit 1
   }
 
-  $asset = $release.coreTools | Where-Object { $_.OS -eq $os -and $_.Architecture -eq $arch }
+  $asset = $release.coreTools | Where-Object { $_.OS -eq $os -and $_.Architecture -eq $arch } | Select-Object -First 1
   if (-not $asset) {
     Write-Error "Could not find a Core Tools download for OS '$os' and arch '$arch'"
     exit 1

--- a/eng/ci/templates/scripts/setup-e2e-tests.ps1
+++ b/eng/ci/templates/scripts/setup-e2e-tests.ps1
@@ -29,42 +29,39 @@ else
 {
   $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
   if ($IsWindows) {
-      $os = "win"
+      $os = "Windows"
   }
   elseif ($IsMacOS) {
-      $os = "osx"
+      $os = "MacOS"
   }
   elseif ($IsLinux) {
-      $os = "linux"
+      $os = "Linux"
   }
   else {
     throw "Unsupported operating system detected. Please run this script on Windows, macOS, or Linux."
   }
 
   Write-Host ""
-  Write-Host "Using latest Core Tools release from GitHub..."
 
-  # GitHub API call for latest release
-  $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/Azure/azure-functions-core-tools/releases/latest" -Headers @{ "User-Agent" = "PowerShell" }
+  # Resolve latest v4 version and download URL from the CLI feed (no auth required)
+  $cliFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json"
+  $cliFeed = Invoke-RestMethod -Uri $cliFeedUrl
+  $version = $cliFeed.tags.v4.release
+  Write-Host "Latest Core Tools version: $version"
 
-  $latestVersion = $releaseInfo.tag_name
-  Write-Host "`nLatest Core Tools version: $latestVersion"
-
-  # Look for zip file matching os and arch
-  $pattern = "Azure\.Functions\.Cli\.$os-$arch\..*\.zip$"
-  $asset = $releaseInfo.assets | Where-Object {
-      $_.name -match $pattern
+  $release = $cliFeed.releases.$version
+  if (-not $release) {
+    Write-Error "Could not find release '$version' in the CLI feed"
+    exit 1
   }
 
+  $asset = $release.coreTools | Where-Object { $_.OS -eq $os -and $_.Architecture -eq $arch }
   if (-not $asset) {
-      Write-Error "Could not find a Core Tools .zip for OS '$os' and arch '$arch'"
-      exit 1
+    Write-Error "Could not find a Core Tools download for OS '$os' and arch '$arch'"
+    exit 1
   }
 
-  $coreToolsURL = $asset.browser_download_url
-
-  # Add query string to avoid caching issues
-  $coreToolsURL = $coreToolsURL + "?raw=true"
+  $coreToolsURL = $asset.downloadLink
 
   Write-Host ""
   Write-Host "---Downloading the Core Tools for Functions V$FunctionsRuntimeVersion---"
@@ -75,14 +72,8 @@ else
   Remove-Item -Force "$FUNC_CLI_DIRECTORY.zip" -ErrorAction Ignore
   Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
 
-  if ($versionUrl)
-  {
-    $version = Invoke-RestMethod -Uri $versionUrl
-    Write-Host "Downloading Functions Core Tools (Version: $version)..."
-  }
-
   $output = "$FUNC_CLI_DIRECTORY.zip"
-  Invoke-RestMethod -Uri $coreToolsURL -OutFile $output
+  Invoke-WebRequest -Uri $coreToolsURL -OutFile $output
 
   Write-Host 'Extracting Functions Core Tools...'
   Expand-Archive $output -DestinationPath $FUNC_CLI_DIRECTORY


### PR DESCRIPTION
### Issue describing the changes in this PR

Replace GitHub API call (which requires auth and is rate-limited) with the Azure Functions CDN feed. The `cli-feed-v4.json` endpoint resolves the latest v4 version without authentication, and the zip download also comes from the CDN directly.

This mirrors the approach taken in [Azure/azure-functions-dotnet-worker#3463](https://github.com/Azure/azure-functions-dotnet-worker/pull/3463).

#### Changes

- **`eng/ci/templates/scripts/setup-e2e-tests.ps1`**: Replaced the `api.github.com` call with the `functionscdn.azureedge.net/public/cli-feed-v4.json` CDN feed to resolve the latest Core Tools v4 version and download URL.
- Removed dead code referencing an unset `$versionUrl` variable.
- Switched from `Invoke-RestMethod` to `Invoke-WebRequest` for the binary download for consistency.
- Updated OS identifier strings to match the CDN feed format (`Windows`/`MacOS`/`Linux` instead of `win`/`osx`/`linux`).

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] I have added all required tests (Unit tests, E2E tests)