### PR TITLE
Onboard dependency feeds to Central Feed Service

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,11 @@
 registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
 @azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/eng/ci/templates/jobs/build-artifacts.yml
+++ b/eng/ci/templates/jobs/build-artifacts.yml
@@ -72,6 +72,8 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/ci/templates/scripts/setup-e2e-tests.ps1
       arguments: '-RepoRoot $(RepoRoot)'
       pwsh: true
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
   - task: DotNetCoreCLI@2
     displayName: Run tests

--- a/eng/ci/templates/jobs/build-artifacts.yml
+++ b/eng/ci/templates/jobs/build-artifacts.yml
@@ -36,6 +36,14 @@ jobs:
       packageType: runtime
       version: '8.x'
 
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate to NuGet feeds
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate to npm feeds
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/.npmrc
+
   - task: DotNetCoreCLI@2
     displayName: Build project
     inputs:


### PR DESCRIPTION
## Summary
- route NuGet restores through the `public/upstream-public` CFS feed
- route the CI global Azurite install through the CFS npm proxy
- authenticate NuGet and npm before restore/install activity and set `NPM_CONFIG_USERCONFIG` on the setup step so `npm install -g` consumes the authenticated repository `.npmrc`
- explicitly map every npm scope in Azurite 3.36.0's resolved production dependency graph: `@azure`, `@azure-rest`, `@colors`, `@dabh`, `@js-joda`, `@microsoft`, `@opentelemetry`, `@so-ric`, `@types`, and `@typespec`

## Validation
- restored and built `Microsoft.Azure.Functions.Extensions.Mcp.sln` in Release through CFS
- passed 1,001 unit tests across the host, worker, and SDK test projects
- performed an isolated `npm install -g azurite@3.36.0` with only `NPM_CONFIG_USERCONFIG` selecting the CFS configuration
- confirmed the configured scope mappings exactly match the lockfile-resolved production graph
- validated npm and NuGet config paths under a Windows directory containing spaces

## Command boundary audit
- CFS URLs are declarative values in `.npmrc` and `NuGet.config`; none are interpolated into a shell or process command string
- the repository-local `.npmrc` path is passed through structured Azure Pipelines inputs/environment rather than shell interpolation
- no changed project, config, source path, or URL has an unquoted command boundary

## Notes
- the full solution test command also starts the E2E suite, which expects a Debug worker app and its external test infrastructure; the Release build produced by the official pipeline does not satisfy that local prerequisite