### PR TITLE
Use cdn.functions.azure.com for Core Tools CLI feed

### DIFF
--- a/eng/ci/templates/scripts/setup-e2e-tests.ps1
+++ b/eng/ci/templates/scripts/setup-e2e-tests.ps1
@@ -44,7 +44,7 @@ else
   Write-Host ""
 
   # Resolve latest v4 version and download URL from the CLI feed (no auth required)
-  $cliFeedUrl = "https://functionscdn.azureedge.net/public/cli-feed-v4.json"
+  $cliFeedUrl = "https://cdn.functions.azure.com/public/cli-feed-v4.json"
   $cliFeed = Invoke-RestMethod -Uri $cliFeedUrl
   $version = $cliFeed.tags.v4.release
   Write-Host "Latest Core Tools version: $version"


### PR DESCRIPTION
`functionscdn.azureedge.net` is being retired (Azure CDN from Edgio shutdown). Switches the E2E test setup script to the current CDN host, `cdn.functions.azure.com`.

Verified the new feed URL resolves correctly (latest v4 release `4.130.0`) and the `downloadLink` entries it returns already point at `cdn.functions.azure.com`, so no other changes are needed.